### PR TITLE
Run cargo fmt

### DIFF
--- a/crates/lexer/src/tests.rs
+++ b/crates/lexer/src/tests.rs
@@ -5,7 +5,9 @@ use super::*;
 use expect_test::{expect, Expect};
 
 fn check_lexing(src: &str, expect: Expect) {
-    let actual: String = tokenize(src).map(|token| format!("{:?}\n", token)).collect();
+    let actual: String = tokenize(src)
+        .map(|token| format!("{:?}\n", token))
+        .collect();
     expect.assert_eq(&actual)
 }
 
@@ -100,7 +102,6 @@ fn nested_block_comments() {
 //         "#]],
 //     );
 // }
-
 
 #[test]
 fn literal_suffixes() {

--- a/crates/lexer/src/unescape.rs
+++ b/crates/lexer/src/unescape.rs
@@ -90,12 +90,10 @@ where
         }
         // FIXME. Makes no sense for bit string
         Mode::Str | Mode::ByteStr | Mode::BitStr => unescape_str_common(src, mode, callback),
- //       Mode::Str | Mode::ByteStr => unescape_str_common(src, mode, callback),
-
+        //       Mode::Str | Mode::ByteStr => unescape_str_common(src, mode, callback),
         Mode::RawStr | Mode::RawByteStr => {
             unescape_raw_str_or_raw_byte_str(src, mode == Mode::RawByteStr, callback)
-        }
-       //  Mode::CStr | Mode::RawCStr => unreachable!(),
+        } //  Mode::CStr | Mode::RawCStr => unreachable!(),
     }
 }
 
@@ -161,13 +159,9 @@ pub enum Mode {
 impl Mode {
     pub fn in_double_quotes(self) -> bool {
         match self {
-            Mode::Str
-            | Mode::BitStr
-            | Mode::ByteStr
-            | Mode::RawStr
-            | Mode::RawByteStr => true,
-//            | Mode::CStr
-//            | Mode::RawCStr => true,
+            Mode::Str | Mode::BitStr | Mode::ByteStr | Mode::RawStr | Mode::RawByteStr => true,
+            //            | Mode::CStr
+            //            | Mode::RawCStr => true,
             Mode::Char | Mode::Byte => false,
         }
     }
@@ -186,23 +180,23 @@ impl Mode {
         match self {
             Mode::Byte | Mode::ByteStr | Mode::RawByteStr | Mode::BitStr => true,
             Mode::Char | Mode::Str | Mode::RawStr => false,
-//                | Mode::CStr | Mode::RawCStr
+            //                | Mode::CStr | Mode::RawCStr
         }
     }
 
     /// Byte literals do not allow unicode escape.
     pub fn is_unicode_escape_disallowed(self) -> bool {
         match self {
-            Mode::Byte | Mode::ByteStr | Mode::RawByteStr | Mode::BitStr  => true,
+            Mode::Byte | Mode::ByteStr | Mode::RawByteStr | Mode::BitStr => true,
             Mode::Char | Mode::Str | Mode::RawStr => false,
-//            Mode::CStr | Mode::RawCStr => false,
+            //            Mode::CStr | Mode::RawCStr => false,
         }
     }
 
     pub fn prefix_noraw(self) -> &'static str {
         match self {
             Mode::Byte | Mode::ByteStr | Mode::RawByteStr => "b",
-//            Mode::CStr | Mode::RawCStr => "c",
+            //            Mode::CStr | Mode::RawCStr => "c",
             Mode::Char | Mode::Str | Mode::RawStr | Mode::BitStr => "",
         }
     }
@@ -261,7 +255,9 @@ fn scan_unicode(
     let mut value: u32 = match chars.next().ok_or(EscapeError::UnclosedUnicodeEscape)? {
         '_' => return Err(EscapeError::LeadingUnderscoreUnicodeEscape),
         '}' => return Err(EscapeError::EmptyUnicodeEscape),
-        c => c.to_digit(16).ok_or(EscapeError::InvalidCharInUnicodeEscape)?,
+        c => c
+            .to_digit(16)
+            .ok_or(EscapeError::InvalidCharInUnicodeEscape)?,
     };
 
     // First character is valid, now parse the rest of the number
@@ -282,15 +278,17 @@ fn scan_unicode(
                 }
 
                 break std::char::from_u32(value).ok_or({
-                     if value > 0x10FFFF {
-                         EscapeError::OutOfRangeUnicodeEscape
-                     } else {
-                         EscapeError::LoneSurrogateUnicodeEscape
-                     }
-                 });
+                    if value > 0x10FFFF {
+                        EscapeError::OutOfRangeUnicodeEscape
+                    } else {
+                        EscapeError::LoneSurrogateUnicodeEscape
+                    }
+                });
             }
             Some(c) => {
-                let digit: u32 = c.to_digit(16).ok_or(EscapeError::InvalidCharInUnicodeEscape)?;
+                let digit: u32 = c
+                    .to_digit(16)
+                    .ok_or(EscapeError::InvalidCharInUnicodeEscape)?;
                 n_digits += 1;
                 if n_digits > 6 {
                     // Stop updating value since we're sure that it's incorrect already.

--- a/crates/lexer/src/unescape/tests.rs
+++ b/crates/lexer/src/unescape/tests.rs
@@ -104,7 +104,9 @@ fn test_unescape_char_good() {
 fn test_unescape_str_warn() {
     fn check(literal: &str, expected: &[(Range<usize>, Result<char, EscapeError>)]) {
         let mut unescaped = Vec::with_capacity(literal.len());
-        unescape_literal(literal, Mode::Str, &mut |range, res| unescaped.push((range, res)));
+        unescape_literal(literal, Mode::Str, &mut |range, res| {
+            unescaped.push((range, res))
+        });
         assert_eq!(unescaped, expected);
     }
 
@@ -121,7 +123,13 @@ fn test_unescape_str_warn() {
             (6..7, Ok('x')),
         ],
     );
-    check("\\\n  \n  x", &[(0..7, Err(EscapeError::MultipleSkippedLinesWarning)), (7..8, Ok('x'))]);
+    check(
+        "\\\n  \n  x",
+        &[
+            (0..7, Err(EscapeError::MultipleSkippedLinesWarning)),
+            (7..8, Ok('x')),
+        ],
+    );
 }
 
 #[test]
@@ -268,23 +276,45 @@ fn test_unescape_byte_str_good() {
 fn test_unescape_raw_str() {
     fn check(literal: &str, expected: &[(Range<usize>, Result<char, EscapeError>)]) {
         let mut unescaped = Vec::with_capacity(literal.len());
-        unescape_literal(literal, Mode::RawStr, &mut |range, res| unescaped.push((range, res)));
+        unescape_literal(literal, Mode::RawStr, &mut |range, res| {
+            unescaped.push((range, res))
+        });
         assert_eq!(unescaped, expected);
     }
 
-    check("\r", &[(0..1, Err(EscapeError::BareCarriageReturnInRawString))]);
-    check("\rx", &[(0..1, Err(EscapeError::BareCarriageReturnInRawString)), (1..2, Ok('x'))]);
+    check(
+        "\r",
+        &[(0..1, Err(EscapeError::BareCarriageReturnInRawString))],
+    );
+    check(
+        "\rx",
+        &[
+            (0..1, Err(EscapeError::BareCarriageReturnInRawString)),
+            (1..2, Ok('x')),
+        ],
+    );
 }
 
 #[test]
 fn test_unescape_raw_byte_str() {
     fn check(literal: &str, expected: &[(Range<usize>, Result<char, EscapeError>)]) {
         let mut unescaped = Vec::with_capacity(literal.len());
-        unescape_literal(literal, Mode::RawByteStr, &mut |range, res| unescaped.push((range, res)));
+        unescape_literal(literal, Mode::RawByteStr, &mut |range, res| {
+            unescaped.push((range, res))
+        });
         assert_eq!(unescaped, expected);
     }
 
-    check("\r", &[(0..1, Err(EscapeError::BareCarriageReturnInRawString))]);
+    check(
+        "\r",
+        &[(0..1, Err(EscapeError::BareCarriageReturnInRawString))],
+    );
     check("🦀", &[(0..4, Err(EscapeError::NonAsciiCharInByte))]);
-    check("🦀a", &[(0..4, Err(EscapeError::NonAsciiCharInByte)), (4..5, Ok('a'))]);
+    check(
+        "🦀a",
+        &[
+            (0..4, Err(EscapeError::NonAsciiCharInByte)),
+            (4..5, Ok('a')),
+        ],
+    );
 }

--- a/crates/oq3_syntax/examples/demotest.rs
+++ b/crates/oq3_syntax/examples/demotest.rs
@@ -1,13 +1,13 @@
 // Copyright contributors to the openqasm-parser project
 
+use clap::{Parser, Subcommand};
 use std::fs;
 use std::path::PathBuf;
-use clap::{Parser, Subcommand};
 
-use rowan::NodeOrToken; // TODO: this can be accessed from a higher level
 use lexer::{tokenize, Token};
+use oq3_syntax::{ast, parse_text, GreenNode, SourceFile};
 use parser::SyntaxKind;
-use oq3_syntax::{ast, parse_text, SourceFile, GreenNode};
+use rowan::NodeOrToken; // TODO: this can be accessed from a higher level
 
 #[derive(Parser)]
 #[command(name = "demotest")]
@@ -57,9 +57,16 @@ fn main() {
         Some(Commands::Parse { filename }) => {
             let parsed_source = SourceFile::parse(&read_example_source(filename));
             let parse_tree: SourceFile = parsed_source.tree();
-            println!("Found {} items", parse_tree.items().collect::<Vec<_>>().len());
+            println!(
+                "Found {} items",
+                parse_tree.items().collect::<Vec<_>>().len()
+            );
             let syntax_errors = parsed_source.errors();
-            println!("Found {} parse errors:\n{:?}\n", syntax_errors.len(), syntax_errors);
+            println!(
+                "Found {} parse errors:\n{:?}\n",
+                syntax_errors.len(),
+                syntax_errors
+            );
             print_tree(parse_tree);
         }
 
@@ -68,7 +75,11 @@ fn main() {
             println!("{:?}", green_node);
             println!("{:?}", green_node.kind());
             print_node_or_token(green_node, 0);
-            println!("\nFound {} parse errors:\n{:?}", syntax_errors.len(), syntax_errors);
+            println!(
+                "\nFound {} parse errors:\n{:?}",
+                syntax_errors.len(),
+                syntax_errors
+            );
         }
 
         Some(Commands::Lex { filename }) => {
@@ -87,7 +98,8 @@ fn main() {
 /// Construct the fqpn of an example from a filename.
 fn example_path(example: &str) -> PathBuf {
     return ["crates", "oq3_syntax", "examples", "oq3_source", example]
-        .iter().collect();
+        .iter()
+        .collect();
 }
 
 fn read_example_source(file_name: &str) -> String {
@@ -98,7 +110,7 @@ fn read_example_source(file_name: &str) -> String {
 }
 
 fn print_tree(file: SourceFile) {
-    use ast::{AstNode};
+    use ast::AstNode;
     for item in file.syntax().descendants() {
         println!("{:?}", item);
     }
@@ -107,18 +119,17 @@ fn print_tree(file: SourceFile) {
 fn print_node_or_token(item: GreenNode, depth: usize) {
     let spcs = " ".repeat(depth);
     for (_i, child) in item.children().enumerate() {
-//        println!("{}{}: {} : {:?}", spcs, i, child, child);
+        //        println!("{}{}: {} : {:?}", spcs, i, child, child);
         match child {
             NodeOrToken::Node(node) => {
                 print_node_or_token(node.to_owned(), depth + 1);
-            },
+            }
             NodeOrToken::Token(token) => {
                 let sk = SyntaxKind::from(token.kind().0);
-//                let sk = token.kind().0;
+                //                let sk = token.kind().0;
                 println!("{}  {:?} {:?}", spcs, sk, token.text());
-            },
+            }
         };
     }
     println!("{}<", spcs);
 }
-

--- a/crates/oq3_syntax/examples/itemparse.rs
+++ b/crates/oq3_syntax/examples/itemparse.rs
@@ -1,8 +1,8 @@
 // Copyright contributors to the openqasm-parser project
 
-use oq3_syntax::SourceFile;
-use oq3_syntax::ast;
 use ast::{HasModuleItem, HasName};
+use oq3_syntax::ast;
+use oq3_syntax::SourceFile;
 
 #[allow(dead_code)]
 fn parse_some_code() {
@@ -43,23 +43,27 @@ int[64] x = 142;
 }
 
 //use parser::syntax_kind::SyntaxKind;
-fn main () {
+fn main() {
     //    parts_testing();
     try_int_def();
-//    parse_some_code();
+    //    parse_some_code();
 }
 
 fn print_item(item: ast::Item) {
     match item {
-        ast::Item::Gate(gate) => {print_gate(gate)},
-        ast::Item::Def(def) => {print_def(def)},
-        ast::Item::DefCal(defcal) => {print_defcal(defcal)},
-        ast::Item::DefCalGrammar(defcg) => {print_defcalgrammar(defcg)},
-        ast::Item::Cal(cal) => {print_cal(cal)},
-        ast::Item::VersionString(version_string) => {print_version_string(version_string)},
-        ast::Item::Include(include) => {print_include(include)},
-        ast::Item::ClassicalDeclarationStatement(type_decl) => {print_type_declaration_statement(type_decl)},
-        _ => {println!("unhandled item: {:?}", item)},
+        ast::Item::Gate(gate) => print_gate(gate),
+        ast::Item::Def(def) => print_def(def),
+        ast::Item::DefCal(defcal) => print_defcal(defcal),
+        ast::Item::DefCalGrammar(defcg) => print_defcalgrammar(defcg),
+        ast::Item::Cal(cal) => print_cal(cal),
+        ast::Item::VersionString(version_string) => print_version_string(version_string),
+        ast::Item::Include(include) => print_include(include),
+        ast::Item::ClassicalDeclarationStatement(type_decl) => {
+            print_type_declaration_statement(type_decl)
+        }
+        _ => {
+            println!("unhandled item: {:?}", item)
+        }
     }
 }
 
@@ -69,15 +73,18 @@ fn parse_print_items(code: &str) {
     let file: SourceFile = parse.tree();
     println!("Found {} items", file.items().collect::<Vec<_>>().len());
     for item in file.items() {
-        print!("desc {}: ", item.syntax().descendants().collect::<Vec<_>>().len());
+        print!(
+            "desc {}: ",
+            item.syntax().descendants().collect::<Vec<_>>().len()
+        );
         print_item(item.clone());
         println!("");
-//        println!("{:?}", item.syntax().descendants().collect::<Vec<_>>());
+        //        println!("{:?}", item.syntax().descendants().collect::<Vec<_>>());
         for d in item.syntax().descendants().collect::<Vec<_>>() {
-//        for d in item.children().collect::<Vec<_>>() {
+            //        for d in item.children().collect::<Vec<_>>() {
             //            print_item(d.clone());
             println!(" {}", d);
-//            println!(" {:?}", d);
+            //            println!(" {:?}", d);
         }
         println!();
     }
@@ -103,7 +110,7 @@ gate mygate q {
             ast::Item::Gate(gate) => {
                 gateitem = Some(gate);
                 break;
-            },
+            }
             _ => (),
         }
     }
@@ -111,7 +118,7 @@ gate mygate q {
 }
 
 #[allow(dead_code)]
-fn test_gate_def(gate: ast::Gate, (name, qubit_list) : (&str, &str)) -> bool {
+fn test_gate_def(gate: ast::Gate, (name, qubit_list): (&str, &str)) -> bool {
     return format!("{}", gate.name().unwrap()) == name
         && format!("{}", gate.qubit_params().unwrap()) == qubit_list;
 }
@@ -139,18 +146,16 @@ fn print_type_declaration_statement(type_decl: ast::ClassicalDeclarationStatemen
     //     println!(" none");
     // }
     print!(" initial value: ");
-    if ! type_decl.expr().is_none() {
+    if !type_decl.expr().is_none() {
         print!("{}", type_decl.expr().unwrap());
-    }
-    else {
+    } else {
         print!(" none");
     }
-
 
     // println!("Type declaration: declared_var.expr '{:?}'", type_decl.declared_var().unwrap().expr());
     // println!(" eq_token {:?}", type_decl.eq_token());
     // println!("        expr '{:?}'", type_decl.expr());
-//    println!("Stub unhandled item: {:?}", type_decl);
+    //    println!("Stub unhandled item: {:?}", type_decl);
 }
 
 fn print_gate(gate: ast::Gate) {
@@ -186,7 +191,10 @@ fn print_def(def: ast::Def) {
 }
 
 fn print_defcalgrammar(defcg: ast::DefCalGrammar) {
-    println!("DefCalgrammar\ndefcalgrammar token: '{}'", defcg.defcalgrammar_token().unwrap());
+    println!(
+        "DefCalgrammar\ndefcalgrammar token: '{}'",
+        defcg.defcalgrammar_token().unwrap()
+    );
     if !defcg.file().is_none() {
         print!("file: '{}'", defcg.file().unwrap());
     } else {
@@ -204,7 +212,10 @@ fn print_cal(cal: ast::Cal) {
 }
 
 fn print_version_string(version_string: ast::VersionString) {
-    println!("VersionString\n openqasm_token: '{}'", version_string.OPENQASM_token().unwrap());
+    println!(
+        "VersionString\n openqasm_token: '{}'",
+        version_string.OPENQASM_token().unwrap()
+    );
     if !version_string.version().is_none() {
         print!("version: '{}'", version_string.version().unwrap());
     } else {
@@ -213,7 +224,10 @@ fn print_version_string(version_string: ast::VersionString) {
 }
 
 fn print_include(include: ast::Include) {
-    println!("Include\ninclude token: '{}'", include.include_token().unwrap());
+    println!(
+        "Include\ninclude token: '{}'",
+        include.include_token().unwrap()
+    );
     if !include.file().is_none() {
         print!("file: '{}'", include.file().unwrap());
     } else {

--- a/crates/oq3_syntax/examples/promote.rs
+++ b/crates/oq3_syntax/examples/promote.rs
@@ -4,15 +4,13 @@
 // And compute the common type that they must be promoted to.
 // You can run this with `cargo run --example promote`
 #[allow(dead_code)]
-
-
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 enum Type {
-    Int {konst: bool, size: u32},
-    UInt {konst: bool, size: u32},
-    Float {konst: bool, size: u32},
-    Angle {konst: bool, size: u32},
-    Complex {konst: bool, size: u32},
+    Int { konst: bool, size: u32 },
+    UInt { konst: bool, size: u32 },
+    Float { konst: bool, size: u32 },
+    Angle { konst: bool, size: u32 },
+    Complex { konst: bool, size: u32 },
     // We could define the following to allow complex numbers outside the spec.
     // Complex {konst: bool, size: u32, rtype: xxx},
     Qubit,
@@ -22,28 +20,37 @@ enum Type {
 #[derive(Clone, Debug)]
 enum BinOp {
     Add,
-    Multiply
+    Multiply,
 }
 
-use crate::Type::{Int, UInt, Float, Angle, Complex, Bottom};
+use crate::Type::{Angle, Bottom, Complex, Float, Int, UInt};
 
 /// Pairs of types int, uint, float, and complex, can be arguments of several binary ops.
 fn _validate_basic_pairs(x: Type, y: Type) -> bool {
     match (x, y) {
-        (UInt {konst: _, size: _} | Int {konst: _, size: _} | Float {konst: _, size: _} | Complex {konst: _, size: _},
-         UInt {konst: _, size: _} | Int {konst: _, size: _} | Float {konst: _, size: _} | Complex {konst: _, size: _})
-            => true,
+        (
+            UInt { konst: _, size: _ }
+            | Int { konst: _, size: _ }
+            | Float { konst: _, size: _ }
+            | Complex { konst: _, size: _ },
+            UInt { konst: _, size: _ }
+            | Int { konst: _, size: _ }
+            | Float { konst: _, size: _ }
+            | Complex { konst: _, size: _ },
+        ) => true,
 
-        (_, _) => false
+        (_, _) => false,
     }
 }
 
 /// Return `true` if `x + y` is defined (not a type error) in OQ3.
 fn valid_args_add(x: Type, y: Type) -> bool {
-    if _validate_basic_pairs(x, y) {return true}
+    if _validate_basic_pairs(x, y) {
+        return true;
+    }
     match (x, y) {
         // "Addition + and subtraction - by other angles of the same size"
-        (Angle {konst: _, size: sx}, Angle {konst: _, size: sy}) => sx == sy,
+        (Angle { konst: _, size: sx }, Angle { konst: _, size: sy }) => sx == sy,
         (_, _) => false,
     }
 }
@@ -53,10 +60,12 @@ fn valid_args_add(x: Type, y: Type) -> bool {
 // Don't know how to reconcile this. We choose the former rule here.
 /// Return `true` if `x * y` is defined (not a type error) in OQ3.
 fn valid_args_multiply(x: Type, y: Type) -> bool {
-    if _validate_basic_pairs(x, y) {return true}
+    if _validate_basic_pairs(x, y) {
+        return true;
+    }
     match (x, y) {
         // "Multiplication * and division / by unsigned integers of the same size."
-        (UInt {konst: _, size: sx}, Angle {konst: _, size: sy}) => sx == sy,
+        (UInt { konst: _, size: sx }, Angle { konst: _, size: sy }) => sx == sy,
 
         (_, _) => false,
     }
@@ -72,39 +81,73 @@ fn valid_args_multiply(x: Type, y: Type) -> bool {
 /// type, if that value is available at compile time.
 fn promote_type(x: Type, y: Type) -> Type {
     if x == y {
-        return x
+        return x;
     }
     match (x, y) {
         // With two integer types, return the wider one.
-        (Int {konst: kx, size: sx}, Int {konst: ky, size: sy}) => {
-            Int {konst: kx && ky, size: std::cmp::max(sx, sy)}
+        (
+            Int {
+                konst: kx,
+                size: sx,
+            },
+            Int {
+                konst: ky,
+                size: sy,
+            },
+        ) => Int {
+            konst: kx && ky,
+            size: std::cmp::max(sx, sy),
         },
 
         // If one is float and the other an integer type, return float
-        (Float {konst: kx, size: sx},
-         Int {konst: ky, size: _} | UInt {konst: ky, size: _}) => {
-            Float {konst: kx && ky, size: sx}
-        }
+        (
+            Float {
+                konst: kx,
+                size: sx,
+            },
+            Int { konst: ky, size: _ } | UInt { konst: ky, size: _ },
+        ) => Float {
+            konst: kx && ky,
+            size: sx,
+        },
 
-        (Angle {konst: kx, size: sx},  UInt {konst: ky, size: sy}) if sx == sy => {
-            Angle {konst: kx && ky, size: sx}
-        }
+        (
+            Angle {
+                konst: kx,
+                size: sx,
+            },
+            UInt {
+                konst: ky,
+                size: sy,
+            },
+        ) if sx == sy => Angle {
+            konst: kx && ky,
+            size: sx,
+        },
 
-        (_, _) => { Bottom } // No rule found for promotion
+        (_, _) => Bottom, // No rule found for promotion
     }
 }
 
-fn _one_call(op: BinOp,  type1: Type, type2: Type) -> Option<Type> {
+fn _one_call(op: BinOp, type1: Type, type2: Type) -> Option<Type> {
     match op {
-        BinOp::Add => { if !valid_args_add(type1, type2) {return None} },
-        BinOp::Multiply => { if !valid_args_multiply(type1, type2) {return None} },
+        BinOp::Add => {
+            if !valid_args_add(type1, type2) {
+                return None;
+            }
+        }
+        BinOp::Multiply => {
+            if !valid_args_multiply(type1, type2) {
+                return None;
+            }
+        }
     }
     let mut otype = promote_type(type1, type2);
     if otype == Bottom {
         otype = promote_type(type2, type1);
     }
     assert!(otype != Bottom);
-    return Some(otype)
+    return Some(otype);
 }
 
 // Analyze a vector of triples (Binary op, type of first arg, type of second arg).
@@ -122,13 +165,83 @@ fn _one_call(op: BinOp,  type1: Type, type2: Type) -> Option<Type> {
 // op: Multiply, t1: UInt { konst: true, size: 64 }, t2: Angle { konst: false, size: 64 } promoted: Angle { konst: false, size: 64 }
 fn try_promotions_for_call() {
     let v = [
-        (BinOp::Add, Int{konst: true, size: 16}, Int{konst: true, size: 16}),
-        (BinOp::Add, Int{konst: true, size: 16}, Int{konst: false, size: 16}),
-        (BinOp::Add, Int{konst: true, size: 16}, Int{konst: false, size: 32}),
-        (BinOp::Add, Int{konst: true, size: 64}, Float{konst: false, size: 32}),
-        (BinOp::Add, UInt{konst: true, size: 64}, Angle{konst: false, size: 32}),
-        (BinOp::Multiply, UInt{konst: true, size: 64}, Angle{konst: false, size: 32}),
-        (BinOp::Multiply, UInt{konst: true, size: 64}, Angle{konst: false, size: 64}),
+        (
+            BinOp::Add,
+            Int {
+                konst: true,
+                size: 16,
+            },
+            Int {
+                konst: true,
+                size: 16,
+            },
+        ),
+        (
+            BinOp::Add,
+            Int {
+                konst: true,
+                size: 16,
+            },
+            Int {
+                konst: false,
+                size: 16,
+            },
+        ),
+        (
+            BinOp::Add,
+            Int {
+                konst: true,
+                size: 16,
+            },
+            Int {
+                konst: false,
+                size: 32,
+            },
+        ),
+        (
+            BinOp::Add,
+            Int {
+                konst: true,
+                size: 64,
+            },
+            Float {
+                konst: false,
+                size: 32,
+            },
+        ),
+        (
+            BinOp::Add,
+            UInt {
+                konst: true,
+                size: 64,
+            },
+            Angle {
+                konst: false,
+                size: 32,
+            },
+        ),
+        (
+            BinOp::Multiply,
+            UInt {
+                konst: true,
+                size: 64,
+            },
+            Angle {
+                konst: false,
+                size: 32,
+            },
+        ),
+        (
+            BinOp::Multiply,
+            UInt {
+                konst: true,
+                size: 64,
+            },
+            Angle {
+                konst: false,
+                size: 64,
+            },
+        ),
     ];
     for (op, type1, type2) in v {
         print!("op: {:?}, t1: {:?}, t2: {:?}", op.clone(), type1, type2);

--- a/crates/oq3_syntax/src/ast.rs
+++ b/crates/oq3_syntax/src/ast.rs
@@ -2,16 +2,16 @@
 
 //! Abstract Syntax Tree, layered on top of untyped `SyntaxNode`s
 
-mod generated;
-mod traits;
-mod token_ext;
-mod node_ext;
-mod expr_ext;
-mod type_ext;
-mod operators;
 pub mod edit;
+mod expr_ext;
+mod generated;
 pub mod make;
+mod node_ext;
+mod operators;
 pub mod prec;
+mod token_ext;
+mod traits;
+mod type_ext;
 
 use std::marker::PhantomData;
 
@@ -25,16 +25,11 @@ use crate::{
 pub use self::{
     expr_ext::{ArrayExprKind, ElseBranch, LiteralKind},
     generated::{nodes::*, tokens::*},
-    node_ext::{
-        HasTextName,
-    },
+    node_ext::HasTextName,
     operators::{ArithOp, BinaryOp, CmpOp, LogicOp, Ordering, RangeOp, UnaryOp},
     token_ext::{CommentKind, CommentShape, IsString, QuoteOffsets, Radix},
-    traits::{
-        HasArgList,
-        HasLoopBody, HasModuleItem, HasName,
-    },
-    type_ext::{ScalarTypeKind}, // need a better name, one that does not clash
+    traits::{HasArgList, HasLoopBody, HasModuleItem, HasName},
+    type_ext::ScalarTypeKind, // need a better name, one that does not clash
 };
 
 // NOTE! "typed ast" here does not mean annotated with types in the target language.
@@ -101,7 +96,10 @@ pub struct AstChildren<N> {
 
 impl<N> AstChildren<N> {
     fn new(parent: &SyntaxNode) -> Self {
-        AstChildren { inner: parent.children(), ph: PhantomData }
+        AstChildren {
+            inner: parent.children(),
+            ph: PhantomData,
+        }
     }
 }
 
@@ -152,7 +150,10 @@ mod support {
     }
 
     pub(super) fn token(parent: &SyntaxNode, kind: SyntaxKind) -> Option<SyntaxToken> {
-        parent.children_with_tokens().filter_map(|it| it.into_token()).find(|it| it.kind() == kind)
+        parent
+            .children_with_tokens()
+            .filter_map(|it| it.into_token())
+            .find(|it| it.kind() == kind)
     }
 }
 

--- a/crates/oq3_syntax/src/ast/expr_ext.rs
+++ b/crates/oq3_syntax/src/ast/expr_ext.rs
@@ -31,7 +31,7 @@ impl ast::Expr {
 
 // FIXME: I mysteriously had to make this public when changing flow control to Stmt
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub  enum ElseBranch {
+pub enum ElseBranch {
     Block(ast::BlockExpr),
     IfStmt(ast::IfStmt),
 }
@@ -85,9 +85,7 @@ impl ast::IfStmt {
             _ => None,
         }
     }
-
 }
-
 
 // FIXME: These tests broke now that IfExpr is a Stmt (Item really)
 // But they should be fixed.
@@ -226,7 +224,6 @@ impl ast::BinExpr {
     }
 }
 
-
 // FIXME: The r-a implementations always return nodes for the all tokens, eg COLONs.
 // Maybe include this later. For now, we only need expressions.
 impl ast::RangeExpr {
@@ -237,7 +234,7 @@ impl ast::RangeExpr {
         let second = children.next();
         let third = children.next();
         if third.is_none() {
-             // start:stop
+            // start:stop
             (first, third, second)
         } else {
             // start:step:stop
@@ -256,7 +253,10 @@ impl ast::IndexExpr {
 }
 
 pub enum ArrayExprKind {
-    Repeat { initializer: Option<ast::Expr>, repeat: Option<ast::Expr> },
+    Repeat {
+        initializer: Option<ast::Expr>,
+        repeat: Option<ast::Expr>,
+    },
     ElementList(AstChildren<ast::Expr>),
 }
 
@@ -402,7 +402,7 @@ impl ast::BlockExpr {
 impl ast::ArgList {
     pub fn altargs(&self) -> Option<ast::Name> {
         let mut children = support::children(self.syntax());
-//        children.next();
+        //        children.next();
         children.next()
     }
 }
@@ -429,12 +429,8 @@ impl ast::GateCallStmt {
     pub fn identifier(&self) -> Option<ast::Identifier> {
         let maybe_id = support::children(self.syntax()).next();
         match maybe_id {
-            Some(ast::Expr::Identifier(ident)) => {
-                Some(ident)
-            }
-            _ => {
-                None
-            }
+            Some(ast::Expr::Identifier(ident)) => Some(ident),
+            _ => None,
         }
     }
 }

--- a/crates/oq3_syntax/src/ast/generated.rs
+++ b/crates/oq3_syntax/src/ast/generated.rs
@@ -18,14 +18,14 @@ pub(crate) use nodes::*;
 impl AstNode for Stmt {
     fn can_cast(kind: SyntaxKind) -> bool {
         match kind {
-//            LET_STMT | EXPR_STMT => true,
+            //            LET_STMT | EXPR_STMT => true,
             EXPR_STMT => true,
             _ => Item::can_cast(kind),
         }
     }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         let res = match syntax.kind() {
-//            LET_STMT => Stmt::LetStmt(LetStmt { syntax }),
+            //            LET_STMT => Stmt::LetStmt(LetStmt { syntax }),
             EXPR_STMT => Stmt::ExprStmt(ExprStmt { syntax }),
             _ => {
                 let item = Item::cast(syntax)?;
@@ -36,7 +36,7 @@ impl AstNode for Stmt {
     }
     fn syntax(&self) -> &SyntaxNode {
         match self {
-//            Stmt::LetStmt(it) => &it.syntax,
+            //            Stmt::LetStmt(it) => &it.syntax,
             Stmt::ExprStmt(it) => &it.syntax,
             Stmt::Item(it) => it.syntax(),
         }

--- a/crates/oq3_syntax/src/ast/make.rs
+++ b/crates/oq3_syntax/src/ast/make.rs
@@ -118,19 +118,32 @@ pub mod tokens {
     pub fn whitespace(text: &str) -> SyntaxToken {
         assert!(text.trim().is_empty());
         let sf = SourceFile::parse(text).ok().unwrap();
-        sf.syntax().clone_for_update().first_child_or_token().unwrap().into_token().unwrap()
+        sf.syntax()
+            .clone_for_update()
+            .first_child_or_token()
+            .unwrap()
+            .into_token()
+            .unwrap()
     }
 
     pub fn doc_comment(text: &str) -> SyntaxToken {
         assert!(!text.trim().is_empty());
         let sf = SourceFile::parse(text).ok().unwrap();
-        sf.syntax().first_child_or_token().unwrap().into_token().unwrap()
+        sf.syntax()
+            .first_child_or_token()
+            .unwrap()
+            .into_token()
+            .unwrap()
     }
 
     pub fn literal(text: &str) -> SyntaxToken {
         assert_eq!(text.trim(), text);
         let lit: ast::Literal = super::ast_from_text(&format!("fn f() {{ let _ = {text}; }}"));
-        lit.syntax().first_child_or_token().unwrap().into_token().unwrap()
+        lit.syntax()
+            .first_child_or_token()
+            .unwrap()
+            .into_token()
+            .unwrap()
     }
 
     pub fn single_newline() -> SyntaxToken {
@@ -164,7 +177,12 @@ pub mod tokens {
             WsBuilder(SourceFile::parse(text).ok().unwrap())
         }
         pub fn ws(&self) -> SyntaxToken {
-            self.0.syntax().first_child_or_token().unwrap().into_token().unwrap()
+            self.0
+                .syntax()
+                .first_child_or_token()
+                .unwrap()
+                .into_token()
+                .unwrap()
         }
     }
 }

--- a/crates/oq3_syntax/src/ast/node_ext.rs
+++ b/crates/oq3_syntax/src/ast/node_ext.rs
@@ -5,7 +5,7 @@
 //!
 //! These methods should only do simple, shallow tasks related to the syntax of the node itself.
 
-use std::{borrow::Cow};
+use std::borrow::Cow;
 
 //use parser::SyntaxKind;
 use rowan::{GreenNodeData, GreenTokenData};
@@ -64,7 +64,11 @@ impl HasTextName for ast::Identifier {}
 
 fn text_of_first_token(node: &SyntaxNode) -> TokenText<'_> {
     fn first_token(green_ref: &GreenNodeData) -> &GreenTokenData {
-        green_ref.children().next().and_then(NodeOrToken::into_token).unwrap()
+        green_ref
+            .children()
+            .next()
+            .and_then(NodeOrToken::into_token)
+            .unwrap()
     }
 
     match node.green() {
@@ -80,10 +84,10 @@ fn text_of_first_token(node: &SyntaxNode) -> TokenText<'_> {
 //         self.statements().into_iter().flat_map(|it| it.statements())
 //        self.statements().into_iter().flat_map(|it| it.statements())
 //    }
-    // only in rust
-    // pub fn tail_expr(&self) -> Option<ast::Expr> {
-    //     self.stmt_list()?.tail_expr()
-    // }
+// only in rust
+// pub fn tail_expr(&self) -> Option<ast::Expr> {
+//     self.stmt_list()?.tail_expr()
+// }
 // }
 
 // impl ast::HasModuleItem for ast::BlockExpr {}

--- a/crates/oq3_syntax/src/ast/operators.rs
+++ b/crates/oq3_syntax/src/ast/operators.rs
@@ -97,10 +97,22 @@ impl fmt::Display for CmpOp {
         let res = match self {
             CmpOp::Eq { negated: false } => "==",
             CmpOp::Eq { negated: true } => "!=",
-            CmpOp::Ord { ordering: Ordering::Less, strict: false } => "<=",
-            CmpOp::Ord { ordering: Ordering::Less, strict: true } => "<",
-            CmpOp::Ord { ordering: Ordering::Greater, strict: false } => ">=",
-            CmpOp::Ord { ordering: Ordering::Greater, strict: true } => ">",
+            CmpOp::Ord {
+                ordering: Ordering::Less,
+                strict: false,
+            } => "<=",
+            CmpOp::Ord {
+                ordering: Ordering::Less,
+                strict: true,
+            } => "<",
+            CmpOp::Ord {
+                ordering: Ordering::Greater,
+                strict: false,
+            } => ">=",
+            CmpOp::Ord {
+                ordering: Ordering::Greater,
+                strict: true,
+            } => ">",
         };
         f.write_str(res)
     }

--- a/crates/oq3_syntax/src/ast/prec.rs
+++ b/crates/oq3_syntax/src/ast/prec.rs
@@ -34,10 +34,10 @@ impl Expr {
             match self {
                 // Cases like `if return {}` (need parens or else `{}` is returned, instead of being `if`'s body)
                 ReturnExpr(e) if e.expr().is_none() => return true,
-//                BreakExpr(e) if e.expr().is_none() => return true, oq3 has no expr after break
+                //                BreakExpr(e) if e.expr().is_none() => return true, oq3 has no expr after break
                 // Same but with `..{}`
                 // FIXME: Verify that branch for RangeExpr is un-needed for OQ3
-//                RangeExpr(e) if matches!(e.end(), Some(BlockExpr(..))) => return true,
+                //                RangeExpr(e) if matches!(e.end(), Some(BlockExpr(..))) => return true,
                 _ => {}
             }
         }
@@ -136,10 +136,10 @@ impl Expr {
             }
             ArrayLiteral(_) => (0, 0), // These need to be checked
             MeasureExpression(_) => (0, 0),
-            BoxExpr(_)  => (0, 27),
+            BoxExpr(_) => (0, 27),
             CallExpr(_) | CastExpression(_) | IndexExpr(_) | IndexedIdentifier(_) => (29, 0),
-            ArrayExpr(_) |  Literal(_) | ParenExpr(_) | Identifier(_) | HardwareQubit(_)
-                | BlockExpr(_) => (0, 0),
+            ArrayExpr(_) | Literal(_) | ParenExpr(_) | Identifier(_) | HardwareQubit(_)
+            | BlockExpr(_) => (0, 0),
         }
     }
 
@@ -158,12 +158,8 @@ impl Expr {
     /// Returns `true` if this expression can't be a standalone statement.
     fn requires_semi_to_be_stmt(&self) -> bool {
         use Expr::*;
-        !matches!(
-            self,
-             BlockExpr(..)
-        )
+        !matches!(self, BlockExpr(..))
     }
-
 
     /// Returns true if self is one of `return`, `break`, `continue` or `yield` with **no associated value**.
     fn is_ret_like_with_no_value(&self) -> bool {
@@ -197,9 +193,12 @@ impl Expr {
                 ArrayLiteral(_) => todo!(),
                 MeasureExpression(_) => todo!(),
                 ArrayExpr(_) | Literal(_) | ParenExpr(_) | Identifier(_) | HardwareQubit(_)
-                    | BlockExpr(_) => None,
+                | BlockExpr(_) => None,
             };
-            token.map(|t| t.text_range()).unwrap_or_else(|| this.syntax().text_range()).start()
+            token
+                .map(|t| t.text_range())
+                .unwrap_or_else(|| this.syntax().text_range())
+                .start()
         }
     }
 
@@ -207,14 +206,12 @@ impl Expr {
         use Expr::*;
 
         match self {
-            ArrayExpr(_) | BlockExpr(_) | CallExpr(_) | CastExpression(_)
-                | IndexExpr(_) | IndexedIdentifier(_) | Literal(_) | Identifier(_) | HardwareQubit(_)
-                | ParenExpr(_) => false,
+            ArrayExpr(_) | BlockExpr(_) | CallExpr(_) | CastExpression(_) | IndexExpr(_)
+            | IndexedIdentifier(_) | Literal(_) | Identifier(_) | HardwareQubit(_)
+            | ParenExpr(_) => false,
 
             // For BinExpr and RangeExpr this is technically wrong -- the child can be on the left...
-            BinExpr(_) | RangeExpr(_) | BoxExpr(_)
-            | ReturnExpr(_)
-                => self
+            BinExpr(_) | RangeExpr(_) | BoxExpr(_) | ReturnExpr(_) => self
                 .syntax()
                 .parent()
                 .and_then(Expr::cast)

--- a/crates/oq3_syntax/src/ast/token_ext.rs
+++ b/crates/oq3_syntax/src/ast/token_ext.rs
@@ -5,9 +5,7 @@
 
 use std::borrow::Cow;
 
-use lexer::unescape::{
-    unescape_byte, unescape_char, unescape_literal,  Mode,
-};
+use lexer::unescape::{unescape_byte, unescape_char, unescape_literal, Mode};
 
 use crate::{
     ast::{self, AstToken},
@@ -51,11 +49,36 @@ impl CommentShape {
 
 impl CommentKind {
     const BY_PREFIX: [(&'static str, CommentKind); 5] = [
-        ("/**/", CommentKind { shape: CommentShape::Block}),
-        ("/***", CommentKind { shape: CommentShape::Block}),
-        ("////", CommentKind { shape: CommentShape::Line}),
-        ("//", CommentKind { shape: CommentShape::Line}),
-        ("/*", CommentKind { shape: CommentShape::Block}),
+        (
+            "/**/",
+            CommentKind {
+                shape: CommentShape::Block,
+            },
+        ),
+        (
+            "/***",
+            CommentKind {
+                shape: CommentShape::Block,
+            },
+        ),
+        (
+            "////",
+            CommentKind {
+                shape: CommentShape::Line,
+            },
+        ),
+        (
+            "//",
+            CommentKind {
+                shape: CommentShape::Line,
+            },
+        ),
+        (
+            "/*",
+            CommentKind {
+                shape: CommentShape::Block,
+            },
+        ),
     ];
 
     pub(crate) fn from_text(text: &str) -> CommentKind {
@@ -67,8 +90,11 @@ impl CommentKind {
     }
 
     pub fn prefix(&self) -> &'static str {
-        let &(prefix, _) =
-            CommentKind::BY_PREFIX.iter().rev().find(|(_, kind)| kind == self).unwrap();
+        let &(prefix, _) = CommentKind::BY_PREFIX
+            .iter()
+            .rev()
+            .find(|(_, kind)| kind == self)
+            .unwrap();
         prefix
     }
 }
@@ -76,7 +102,8 @@ impl CommentKind {
 impl ast::Whitespace {
     pub fn spans_multiple_lines(&self) -> bool {
         let text = self.text();
-        text.find('\n').map_or(false, |idx| text[idx + 1..].contains('\n'))
+        text.find('\n')
+            .map_or(false, |idx| text[idx + 1..].contains('\n'))
     }
 }
 
@@ -100,7 +127,10 @@ impl QuoteOffsets {
         let end = TextSize::of(literal);
 
         let res = QuoteOffsets {
-            quotes: (TextRange::new(start, left_quote), TextRange::new(right_quote, end)),
+            quotes: (
+                TextRange::new(start, left_quote),
+                TextRange::new(right_quote, end),
+            ),
             contents: TextRange::new(left_quote, right_quote),
         };
         Some(res)
@@ -146,8 +176,10 @@ pub trait IsString: AstToken {
         let offset = text_range_no_quotes.start() - start;
 
         unescape_literal(text, Self::MODE, &mut |range, unescaped_char| {
-            let text_range =
-                TextRange::new(range.start.try_into().unwrap(), range.end.try_into().unwrap());
+            let text_range = TextRange::new(
+                range.start.try_into().unwrap(),
+                range.end.try_into().unwrap(),
+            );
             cb(text_range + offset, unescaped_char);
         });
     }
@@ -202,7 +234,6 @@ impl ast::String {
     }
 }
 
-
 // FIXME: RAW_PREFIX is a crufty artifact. It's not used in OQ3.
 impl IsString for ast::BitString {
     const RAW_PREFIX: &'static str = "br";
@@ -210,12 +241,10 @@ impl IsString for ast::BitString {
 }
 
 impl ast::BitString {
-
     // The bitstring has only '0' and '1'
     pub fn value(&self) -> Option<Cow<'_, str>> {
         let text = self.text();
-        let text =
-            &text[self.text_range_between_quotes()? - self.syntax().text_range().start()];
+        let text = &text[self.text_range_between_quotes()? - self.syntax().text_range().start()];
         return Some(Cow::Borrowed(text));
     }
 
@@ -308,7 +337,10 @@ impl ast::FloatNumber {
 
     /// Return `true` if the float literal contains no characters that are not digits or '.'
     pub fn is_simple(&self) -> bool {
-        self.text().char_indices().by_ref().all(|(_, c)| c.is_ascii_digit() || c == '.')
+        self.text()
+            .char_indices()
+            .by_ref()
+            .all(|(_, c)| c.is_ascii_digit() || c == '.')
     }
 
     // FIXME: this is not working currently
@@ -386,8 +418,12 @@ pub enum Radix {
 }
 
 impl Radix {
-    pub const ALL: &'static [Radix] =
-        &[Radix::Binary, Radix::Octal, Radix::Decimal, Radix::Hexadecimal];
+    pub const ALL: &'static [Radix] = &[
+        Radix::Binary,
+        Radix::Octal,
+        Radix::Decimal,
+        Radix::Hexadecimal,
+    ];
 
     const fn prefix_len(self) -> usize {
         match self {
@@ -402,25 +438,55 @@ mod tests {
     use crate::ast::{self, make, FloatNumber, IntNumber};
 
     fn check_float_suffix<'a>(lit: &str, expected: impl Into<Option<&'a str>>) {
-        assert_eq!(FloatNumber { syntax: make::tokens::literal(lit) }.suffix(), expected.into());
+        assert_eq!(
+            FloatNumber {
+                syntax: make::tokens::literal(lit)
+            }
+            .suffix(),
+            expected.into()
+        );
     }
 
     fn check_int_suffix<'a>(lit: &str, expected: impl Into<Option<&'a str>>) {
-        assert_eq!(IntNumber { syntax: make::tokens::literal(lit) }.suffix(), expected.into());
+        assert_eq!(
+            IntNumber {
+                syntax: make::tokens::literal(lit)
+            }
+            .suffix(),
+            expected.into()
+        );
     }
 
     fn check_float_value(lit: &str, expected: impl Into<Option<f64>> + Copy) {
-        assert_eq!(FloatNumber { syntax: make::tokens::literal(lit) }.value(), expected.into());
-        assert_eq!(IntNumber { syntax: make::tokens::literal(lit) }.float_value(), expected.into());
+        assert_eq!(
+            FloatNumber {
+                syntax: make::tokens::literal(lit)
+            }
+            .value(),
+            expected.into()
+        );
+        assert_eq!(
+            IntNumber {
+                syntax: make::tokens::literal(lit)
+            }
+            .float_value(),
+            expected.into()
+        );
     }
 
     fn check_int_value(lit: &str, expected: impl Into<Option<u128>>) {
-        assert_eq!(IntNumber { syntax: make::tokens::literal(lit) }.value(), expected.into());
+        assert_eq!(
+            IntNumber {
+                syntax: make::tokens::literal(lit)
+            }
+            .value(),
+            expected.into()
+        );
     }
 
     #[test]
     fn test_float_number_suffix() {
-         check_float_suffix("123.0", None);
+        check_float_suffix("123.0", None);
         check_float_suffix("123f32", "f32");
         check_float_suffix("123.0e", None);
         check_float_suffix("123.0e4", None);
@@ -444,7 +510,11 @@ mod tests {
 
     fn check_string_value<'a>(lit: &str, expected: impl Into<Option<&'a str>>) {
         assert_eq!(
-            ast::String { syntax: make::tokens::literal(&format!("\"{lit}\"")) }.value().as_deref(),
+            ast::String {
+                syntax: make::tokens::literal(&format!("\"{lit}\""))
+            }
+            .value()
+            .as_deref(),
             expected.into()
         );
     }
@@ -462,38 +532,38 @@ bcde", "abcde",
         );
     }
 
-//     fn check_byte_string_value<'a, const N: usize>(
-//         lit: &str,
-//         expected: impl Into<Option<&'a [u8; N]>>,
-//     ) {
-//         assert_eq!(
-//             ast::ByteString { syntax: make::tokens::literal(&format!("b\"{lit}\"")) }
-//                 .value()
-//                 .as_deref(),
-//             expected.into().map(|value| &value[..])
-//         );
-//     }
+    //     fn check_byte_string_value<'a, const N: usize>(
+    //         lit: &str,
+    //         expected: impl Into<Option<&'a [u8; N]>>,
+    //     ) {
+    //         assert_eq!(
+    //             ast::ByteString { syntax: make::tokens::literal(&format!("b\"{lit}\"")) }
+    //                 .value()
+    //                 .as_deref(),
+    //             expected.into().map(|value| &value[..])
+    //         );
+    //     }
 
-//     #[test]
-//     fn test_byte_string_escape() {
-//         check_byte_string_value(r"foobar", b"foobar");
-//         check_byte_string_value(r"\foobar", None::<&[u8; 0]>);
-//         check_byte_string_value(r"\nfoobar", b"\nfoobar");
-//         check_byte_string_value(r"C:\\Windows\\System32\\", b"C:\\Windows\\System32\\");
-//         check_byte_string_value(r"\x61bcde", b"abcde");
-//         check_byte_string_value(
-//             r"a\
-// bcde", b"abcde",
-//         );
-//     }
+    //     #[test]
+    //     fn test_byte_string_escape() {
+    //         check_byte_string_value(r"foobar", b"foobar");
+    //         check_byte_string_value(r"\foobar", None::<&[u8; 0]>);
+    //         check_byte_string_value(r"\nfoobar", b"\nfoobar");
+    //         check_byte_string_value(r"C:\\Windows\\System32\\", b"C:\\Windows\\System32\\");
+    //         check_byte_string_value(r"\x61bcde", b"abcde");
+    //         check_byte_string_value(
+    //             r"a\
+    // bcde", b"abcde",
+    //         );
+    //     }
 
     #[test]
     fn test_value_underscores() {
         check_float_value("1.234567891011121_f64", 1.234567891011121_f64);
         // FIXME GJL. Introducing SimpleFloat broke this.
-       check_float_value("1__0.__0__f32", 10.0);
-       check_int_value("0b__1_0_", 2);
-       check_int_value("1_1_1_1_1_1", 111111);
+        check_float_value("1__0.__0__f32", 10.0);
+        check_int_value("0b__1_0_", 2);
+        check_int_value("1_1_1_1_1_1", 111111);
     }
 }
 

--- a/crates/oq3_syntax/src/ast/traits.rs
+++ b/crates/oq3_syntax/src/ast/traits.rs
@@ -9,9 +9,7 @@
 
 use either::Either;
 
-use crate::{
-    ast::{self, support, AstChildren, AstNode},
-};
+use crate::ast::{self, support, AstChildren, AstNode};
 
 pub trait HasName: AstNode {
     fn name(&self) -> Option<ast::Name> {
@@ -47,7 +45,6 @@ pub trait HasModuleItem: AstNode {
         support::children(self.syntax())
     }
 }
-
 
 // pub trait HasAttrs: AstNode {
 //     fn attrs(&self) -> AstChildren<ast::Attr> {

--- a/crates/oq3_syntax/src/ptr.rs
+++ b/crates/oq3_syntax/src/ptr.rs
@@ -32,7 +32,10 @@ pub struct AstPtr<N: AstNode> {
 
 impl<N: AstNode> Clone for AstPtr<N> {
     fn clone(&self) -> AstPtr<N> {
-        AstPtr { raw: self.raw, _ty: PhantomData }
+        AstPtr {
+            raw: self.raw,
+            _ty: PhantomData,
+        }
     }
 }
 
@@ -52,7 +55,10 @@ impl<N: AstNode> Hash for AstPtr<N> {
 
 impl<N: AstNode> AstPtr<N> {
     pub fn new(node: &N) -> AstPtr<N> {
-        AstPtr { raw: SyntaxNodePtr::new(node.syntax()), _ty: PhantomData }
+        AstPtr {
+            raw: SyntaxNodePtr::new(node.syntax()),
+            _ty: PhantomData,
+        }
     }
 
     pub fn to_node(&self, root: &SyntaxNode) -> N {
@@ -72,19 +78,28 @@ impl<N: AstNode> AstPtr<N> {
         if !U::can_cast(self.raw.kind()) {
             return None;
         }
-        Some(AstPtr { raw: self.raw, _ty: PhantomData })
+        Some(AstPtr {
+            raw: self.raw,
+            _ty: PhantomData,
+        })
     }
 
     pub fn upcast<M: AstNode>(self) -> AstPtr<M>
     where
         N: Into<M>,
     {
-        AstPtr { raw: self.raw, _ty: PhantomData }
+        AstPtr {
+            raw: self.raw,
+            _ty: PhantomData,
+        }
     }
 
     /// Like `SyntaxNodePtr::cast` but the trait bounds work out.
     pub fn try_from_raw(raw: SyntaxNodePtr) -> Option<AstPtr<N>> {
-        N::can_cast(raw.kind()).then_some(AstPtr { raw, _ty: PhantomData })
+        N::can_cast(raw.kind()).then_some(AstPtr {
+            raw,
+            _ty: PhantomData,
+        })
     }
 }
 

--- a/crates/oq3_syntax/src/syntax_node.rs
+++ b/crates/oq3_syntax/src/syntax_node.rs
@@ -14,7 +14,7 @@ use crate::{Parse, SyntaxError, SyntaxKind, TextSize};
 
 // FIXME: GJL Using this in demo program, so make it public.
 // actually rustc should warn if this is not used.
-pub use rowan::{GreenNode};
+pub use rowan::GreenNode;
 // pub(crate) use rowan::{GreenNode};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -37,7 +37,6 @@ pub type SyntaxElement = rowan::SyntaxElement<OpenQASM3Language>;
 pub type SyntaxNodeChildren = rowan::SyntaxNodeChildren<OpenQASM3Language>;
 pub type SyntaxElementChildren = rowan::SyntaxElementChildren<OpenQASM3Language>;
 pub type PreorderWithTokens = rowan::api::PreorderWithTokens<OpenQASM3Language>;
-
 
 #[derive(Default)]
 pub struct SyntaxTreeBuilder {
@@ -77,6 +76,7 @@ impl SyntaxTreeBuilder {
     }
 
     pub fn error(&mut self, error: String, text_pos: TextSize) {
-        self.errors.push(SyntaxError::new_at_offset(error, text_pos));
+        self.errors
+            .push(SyntaxError::new_at_offset(error, text_pos));
     }
 }

--- a/crates/oq3_syntax/src/ted.rs
+++ b/crates/oq3_syntax/src/ted.rs
@@ -155,7 +155,7 @@ fn ws_before(position: &Position, new: &SyntaxElement) -> Option<SyntaxToken> {
         PositionRepr::After(it) => it,
     };
     if prev.kind() == T!['{'] && ast::Stmt::can_cast(new.kind()) {
-//        if let Some(stmt_list) = prev.parent().and_then(ast::StmtList::cast) {
+        //        if let Some(stmt_list) = prev.parent().and_then(ast::StmtList::cast) {
         if let Some(stmt_list) = prev.parent().and_then(ast::BlockExpr::cast) {
             let mut indent = IndentLevel::from_element(&stmt_list.syntax().clone().into());
             indent.0 += 1;

--- a/crates/oq3_syntax/src/tests.rs
+++ b/crates/oq3_syntax/src/tests.rs
@@ -6,20 +6,20 @@ mod ast_src;
 mod sourcegen_ast;
 
 use crate::ast;
-use crate::ast::{HasModuleItem}; // for file.items()
-use crate::ast::{HasTextName}; // for methods: text(), string()
-//use oq3_syntax::ast;
-// use std::{
-//    fs,
-//    path::{Path, PathBuf},
-// };
-// use ast::HasName;
-//use expect_test::expect_file;
-// use rayon::prelude::*;
-// Adds complication from rust-analyzer
-// use test_utils::{bench, bench_fixture, project_root};
-//use crate::{ast, AstNode, SourceFile, SyntaxError};
-use crate::{SourceFile};
+use crate::ast::HasModuleItem; // for file.items()
+use crate::ast::HasTextName; // for methods: text(), string()
+                             //use oq3_syntax::ast;
+                             // use std::{
+                             //    fs,
+                             //    path::{Path, PathBuf},
+                             // };
+                             // use ast::HasName;
+                             //use expect_test::expect_file;
+                             // use rayon::prelude::*;
+                             // Adds complication from rust-analyzer
+                             // use test_utils::{bench, bench_fixture, project_root};
+                             //use crate::{ast, AstNode, SourceFile, SyntaxError};
+use crate::SourceFile;
 
 // fn collect_items(code: &str) -> (usize, Vec<ast::Item>){
 //     let parse = SourceFile::parse(code);
@@ -94,7 +94,6 @@ h q; ()
     let parse = SourceFile::parse(code);
     assert_eq!(parse.errors.len(), 1);
 }
-
 
 #[test]
 fn parse_let_test() {
@@ -188,7 +187,6 @@ defcal xmeasure(int a, int b) q, p -> {
     assert_eq!(parse.errors.len(), 1);
 }
 
-
 #[test]
 fn parse_qasm_defcal_test() {
     let code = r##"
@@ -226,7 +224,7 @@ def xmeasure(q) -> bit {
 
 #[test]
 fn with_details_test() {
-    use crate::{ast};
+    use crate::ast;
     use ast::{HasModuleItem, HasName};
 
     let code = r##"
@@ -262,7 +260,7 @@ int x;
    "##;
     let parse = SourceFile::parse(code);
     assert!(parse.errors().is_empty());
-//    let file: SourceFile = parse.tree();
+    //    let file: SourceFile = parse.tree();
     let mut items = parse.tree().items();
     let decl = match items.next() {
         Some(ast::Item::ClassicalDeclarationStatement(s)) => s,
@@ -278,16 +276,16 @@ int x;
     // println!(" token {}", scalar_type.token());
     // println!(" token {:?}", scalar_type.token());
 
-//        Some(ast::Item::ClassicalDeclarationStatement(s)) => Some(s),
-//    assert_eq!(0, 1);
+    //        Some(ast::Item::ClassicalDeclarationStatement(s)) => Some(s),
+    //    assert_eq!(0, 1);
     // for item in items {
     //     match item {
     //         ast::Item::ClassicalDeclarationStatement(s) => decl = Some(s),
     //         _ => unreachable!(),
     //     }
     // }
-//    return item
-//    let ast::Item::ClassicalDeclarationStatement(_)> =
+    //    return item
+    //    let ast::Item::ClassicalDeclarationStatement(_)> =
 }
 
 #[test]
@@ -353,4 +351,3 @@ z + int[32](x);
     let parse = SourceFile::parse(code);
     assert_eq!(parse.errors.len(), 2);
 }
-

--- a/crates/oq3_syntax/src/tests/ast_src.rs
+++ b/crates/oq3_syntax/src/tests/ast_src.rs
@@ -68,29 +68,65 @@ pub(crate) const KINDS_SRC: KindsSrc<'_> = KindsSrc {
         (">>=", "SHREQ"),
     ],
     keywords: &[
-        "OPENQASM", "include", "def", "defcalgrammar", "cal", "defcal", "gate",
-        "delay", "reset", "measure",
-        "pragma",  "end",
-        "let",  "box", "extern",
-        "const", "barrier",
+        "OPENQASM",
+        "include",
+        "def",
+        "defcalgrammar",
+        "cal",
+        "defcal",
+        "gate",
+        "delay",
+        "reset",
+        "measure",
+        "pragma",
+        "end",
+        "let",
+        "box",
+        "extern",
+        "const",
+        "barrier",
         "gphase", // This is a slight hack because a `gphase` call has unique syntax.
-
         // Flow control
-        "if", "else", "for", "in", "while", "continue", "return", "break",
-
+        "if",
+        "else",
+        "for",
+        "in",
+        "while",
+        "continue",
+        "return",
+        "break",
         // Types
-        "input", "output", "readonly", "mutable", "qreg", "creg",
-        "qubit", "void", "array",
-
+        "input",
+        "output",
+        "readonly",
+        "mutable",
+        "qreg",
+        "creg",
+        "qubit",
+        "void",
+        "array",
         // I suppose these are literals
-        "false", "true",
+        "false",
+        "true",
     ],
     // GJL: try introducing scalar_types to help parse var declarations. May not be useful
     // sourcegen_ast.rs can convert these to upper snake case.
-    scalar_types: &["float", "int", "uint", "complex", "bool", "bit", "duration", "stretch",  "angle"],
+    scalar_types: &[
+        "float", "int", "uint", "complex", "bool", "bit", "duration", "stretch", "angle",
+    ],
     // These are already upper snake case.
-    literals: &["INT_NUMBER", "FLOAT_NUMBER", "SIMPLE_FLOAT_NUMBER", "CHAR", "BYTE", "STRING", "BIT_STRING", "TIMING_FLOAT_NUMBER", "TIMING_INT_NUMBER"],
-    tokens: &["ERROR", "IDENT", "HARDWAREIDENT", "WHITESPACE", "COMMENT",], // FIXME, prob remove HARDWAREIDENT
+    literals: &[
+        "INT_NUMBER",
+        "FLOAT_NUMBER",
+        "SIMPLE_FLOAT_NUMBER",
+        "CHAR",
+        "BYTE",
+        "STRING",
+        "BIT_STRING",
+        "TIMING_FLOAT_NUMBER",
+        "TIMING_INT_NUMBER",
+    ],
+    tokens: &["ERROR", "IDENT", "HARDWAREIDENT", "WHITESPACE", "COMMENT"], // FIXME, prob remove HARDWAREIDENT
     nodes: &[
         "SOURCE_FILE",
         "GATE",
@@ -121,7 +157,7 @@ pub(crate) const KINDS_SRC: KindsSrc<'_> = KindsSrc {
         "BLOCK_EXPR",
         "STMT_LIST",
         "RETURN_EXPR",
-//        "LET_EXPR",
+        //        "LET_EXPR",
         "LET_STMT",
         "ALIAS_EXPR",
         "CONCATENATION_EXPR",
@@ -182,7 +218,7 @@ pub(crate) const KINDS_SRC: KindsSrc<'_> = KindsSrc {
         "INDEX_KIND",
         "INDEXED_IDENTIFIER",
         "IDENTIFIER",
-//        "EXPR_OR_RANGE", // Remove if we dont take this route
+        //        "EXPR_OR_RANGE", // Remove if we dont take this route
         "ARRAY_LITERAL",
         "HARDWARE_QUBIT",
         "CLASSICAL_DECLARATION_STATEMENT",
@@ -215,7 +251,11 @@ pub(crate) struct AstNodeSrc {
 #[derive(Debug, Eq, PartialEq)]
 pub(crate) enum Field {
     Token(String),
-    Node { name: String, ty: String, cardinality: Cardinality },
+    Node {
+        name: String,
+        ty: String,
+        cardinality: Cardinality,
+    },
 }
 
 #[derive(Debug, Eq, PartialEq)]

--- a/crates/oq3_syntax/src/tests/sourcegen_ast.rs
+++ b/crates/oq3_syntax/src/tests/sourcegen_ast.rs
@@ -34,7 +34,7 @@ fn our_project_root() -> PathBuf {
 /// The generated file _syntax_kind_enum.rs must be copied to syntax_kind_enum.rs.
 #[test]
 fn write_syntax_kinds_enum() {
-    let  syntax_kinds = generate_syntax_kinds(KINDS_SRC);
+    let syntax_kinds = generate_syntax_kinds(KINDS_SRC);
     let syntax_kinds_file =
         our_project_root().join("crates/parser/src/syntax_kind/_syntax_kind_enum.rs");
     sourcegen::ensure_file_contents(syntax_kinds_file.as_path(), &syntax_kinds);
@@ -42,8 +42,9 @@ fn write_syntax_kinds_enum() {
 
 /// Read the ungrammar from openqasm3.ungram, lower to the AST, and return the result.
 fn _generate_ast() -> AstSrc {
-    let grammar =
-        include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/openqasm3.ungram")).parse().unwrap();
+    let grammar = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/openqasm3.ungram"))
+        .parse()
+        .unwrap();
     let ast = lower(&grammar);
     println!("AST: {:?}", ast);
     return ast;
@@ -69,7 +70,8 @@ fn sourcegen_ast_nodes() {
     let ast = _generate_ast();
 
     let ast_nodes = generate_nodes(KINDS_SRC, &ast);
-    let ast_nodes_file = our_project_root().join("crates/oq3_syntax/src/ast/generated/_new_nodes.rs");
+    let ast_nodes_file =
+        our_project_root().join("crates/oq3_syntax/src/ast/generated/_new_nodes.rs");
     sourcegen::ensure_file_contents(ast_nodes_file.as_path(), &ast_nodes);
 }
 
@@ -192,7 +194,11 @@ fn generate_nodes(kinds: KindsSrc<'_>, grammar: &AstSrc) -> String {
         .enums
         .iter()
         .map(|en| {
-            let variants: Vec<_> = en.variants.iter().map(|var| format_ident!("{}", var)).collect();
+            let variants: Vec<_> = en
+                .variants
+                .iter()
+                .map(|var| format_ident!("{}", var))
+                .collect();
             let name = format_ident!("{}", en.name);
             let kinds: Vec<_> = variants
                 .iter()
@@ -307,8 +313,10 @@ fn generate_nodes(kinds: KindsSrc<'_>, grammar: &AstSrc) -> String {
     let enum_names = grammar.enums.iter().map(|it| &it.name);
     let node_names = grammar.nodes.iter().map(|it| &it.name);
 
-    let display_impls =
-        enum_names.chain(node_names.clone()).map(|it| format_ident!("{}", it)).map(|name| {
+    let display_impls = enum_names
+        .chain(node_names.clone())
+        .map(|it| format_ident!("{}", it))
+        .map(|name| {
             quote! {
                 impl std::fmt::Display for #name {
                     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -352,8 +360,11 @@ fn generate_nodes(kinds: KindsSrc<'_>, grammar: &AstSrc) -> String {
 
     let mut res = String::with_capacity(ast.len() * 2);
 
-    let mut docs =
-        grammar.nodes.iter().map(|it| &it.doc).chain(grammar.enums.iter().map(|it| &it.doc));
+    let mut docs = grammar
+        .nodes
+        .iter()
+        .map(|it| &it.doc)
+        .chain(grammar.enums.iter().map(|it| &it.doc));
 
     for chunk in ast.split("# [pretty_doc_comment_placeholder_workaround] ") {
         res.push_str(chunk);
@@ -362,7 +373,7 @@ fn generate_nodes(kinds: KindsSrc<'_>, grammar: &AstSrc) -> String {
         }
     }
 
-//    let res = sourcegen::add_preamble("sourcegen_ast", sourcegen::reformat(res)); FIXME
+    //    let res = sourcegen::add_preamble("sourcegen_ast", sourcegen::reformat(res)); FIXME
     let res = sourcegen::add_preamble("sourcegen_ast", res);
     res.replace("#[derive", "\n#[derive")
 }
@@ -390,8 +401,11 @@ fn generate_syntax_kinds(grammar: KindsSrc<'_>) -> String {
             quote! { #(#cs)* }
         }
     });
-    let punctuation =
-        grammar.punct.iter().map(|(_token, name)| format_ident!("{}", name)).collect::<Vec<_>>();
+    let punctuation = grammar
+        .punct
+        .iter()
+        .map(|(_token, name)| format_ident!("{}", name))
+        .collect::<Vec<_>>();
 
     let upper_snake = |&name| match name {
         "Self" => format_ident!("SELF_TYPE_KW"),
@@ -406,24 +420,40 @@ fn generate_syntax_kinds(grammar: KindsSrc<'_>) -> String {
     let all_keywords_values = grammar
         .keywords
         .iter()
-//        .chain(grammar.contextual_keywords.iter())
+        //        .chain(grammar.contextual_keywords.iter())
         .copied()
         .collect::<Vec<_>>();
     let all_keywords_idents = all_keywords_values.iter().map(|kw| format_ident!("{}", kw));
-    let all_keywords = all_keywords_values.iter().map(upper_snake).collect::<Vec<_>>();
+    let all_keywords = all_keywords_values
+        .iter()
+        .map(upper_snake)
+        .collect::<Vec<_>>();
 
     let scalar_types_values = grammar.scalar_types.iter().collect::<Vec<_>>();
     let scalar_types_idents = scalar_types_values.iter().map(|ty| format_ident!("{}", ty));
-    let scalar_types =
-        scalar_types_values.iter().map(|ty| format_ident!("{}_TY", to_upper_snake_case(ty))).collect::<Vec<_>>();
-//        grammar.scalar_types.iter().map(|name| format_ident!("{}", name)).collect::<Vec<_>>();
+    let scalar_types = scalar_types_values
+        .iter()
+        .map(|ty| format_ident!("{}_TY", to_upper_snake_case(ty)))
+        .collect::<Vec<_>>();
+    //        grammar.scalar_types.iter().map(|name| format_ident!("{}", name)).collect::<Vec<_>>();
 
-    let literals =
-        grammar.literals.iter().map(|name| format_ident!("{}", name)).collect::<Vec<_>>();
+    let literals = grammar
+        .literals
+        .iter()
+        .map(|name| format_ident!("{}", name))
+        .collect::<Vec<_>>();
 
-    let tokens = grammar.tokens.iter().map(|name| format_ident!("{}", name)).collect::<Vec<_>>();
+    let tokens = grammar
+        .tokens
+        .iter()
+        .map(|name| format_ident!("{}", name))
+        .collect::<Vec<_>>();
 
-    let nodes = grammar.nodes.iter().map(|name| format_ident!("{}", name)).collect::<Vec<_>>();
+    let nodes = grammar
+        .nodes
+        .iter()
+        .map(|name| format_ident!("{}", name))
+        .collect::<Vec<_>>();
 
     // FIXME: find out how to insert a plain old comment in the quoted thing.
     // Usual double slash quotes are ommited. trip slash quotes are converted to some kind of doc macro.
@@ -510,7 +540,7 @@ fn generate_syntax_kinds(grammar: KindsSrc<'_>) -> String {
         pub use T;
     };
 
-//    sourcegen::add_preamble("sourcegen_ast", sourcegen::reformat(ast.to_string())) // FIXME
+    //    sourcegen::add_preamble("sourcegen_ast", sourcegen::reformat(ast.to_string())) // FIXME
     sourcegen::add_preamble("sourcegen_ast", ast.to_string())
 }
 
@@ -564,7 +594,13 @@ fn pluralize(s: &str) -> String {
 
 impl Field {
     fn is_many(&self) -> bool {
-        matches!(self, Field::Node { cardinality: Cardinality::Many, .. })
+        matches!(
+            self,
+            Field::Node {
+                cardinality: Cardinality::Many,
+                ..
+            }
+        )
     }
     fn token_kind(&self) -> Option<proc_macro2::TokenStream> {
         match self {
@@ -642,20 +678,30 @@ fn lower(grammar: &Grammar) -> AstSrc {
 
     let nodes = grammar.iter().collect::<Vec<_>>();
 
-//    println!("lower:    let nodes = grammar.iter().collect::<Vec<_>>();");
+    //    println!("lower:    let nodes = grammar.iter().collect::<Vec<_>>();");
     for &node in &nodes {
         let name = grammar[node].name.clone();
         let rule = &grammar[node].rule;
-//        println!("lower: name rule");
+        //        println!("lower: name rule");
         match lower_enum(grammar, rule) {
             Some(variants) => {
-                let enum_src = AstEnumSrc { doc: Vec::new(), name, traits: Vec::new(), variants };
+                let enum_src = AstEnumSrc {
+                    doc: Vec::new(),
+                    name,
+                    traits: Vec::new(),
+                    variants,
+                };
                 res.enums.push(enum_src);
             }
             None => {
                 let mut fields = Vec::new();
                 lower_rule(&mut fields, grammar, None, rule);
-                res.nodes.push(AstNodeSrc { doc: Vec::new(), name, traits: Vec::new(), fields });
+                res.nodes.push(AstNodeSrc {
+                    doc: Vec::new(),
+                    name,
+                    traits: Vec::new(),
+                    fields,
+                });
             }
         }
     }
@@ -699,8 +745,12 @@ fn lower_rule(acc: &mut Vec<Field>, grammar: &Grammar, label: Option<&String>, r
         Rule::Node(node) => {
             let ty = grammar[*node].name.clone();
             let name = label.cloned().unwrap_or_else(|| to_lower_snake_case(&ty));
-//            println!("Node name {:?}", name);
-            let field = Field::Node { name, ty, cardinality: Cardinality::Optional };
+            //            println!("Node name {:?}", name);
+            let field = Field::Node {
+                name,
+                ty,
+                cardinality: Cardinality::Optional,
+            };
             acc.push(field);
         }
         // Token(Token), A token, like `'struct'`.
@@ -723,8 +773,14 @@ fn lower_rule(acc: &mut Vec<Field>, grammar: &Grammar, label: Option<&String>, r
         Rule::Rep(inner) => {
             if let Rule::Node(node) = &**inner {
                 let ty = grammar[*node].name.clone();
-                let name = label.cloned().unwrap_or_else(|| pluralize(&to_lower_snake_case(&ty)));
-                let field = Field::Node { name, ty, cardinality: Cardinality::Many };
+                let name = label
+                    .cloned()
+                    .unwrap_or_else(|| pluralize(&to_lower_snake_case(&ty)));
+                let field = Field::Node {
+                    name,
+                    ty,
+                    cardinality: Cardinality::Many,
+                };
                 acc.push(field);
                 return;
             }
@@ -741,9 +797,12 @@ fn lower_rule(acc: &mut Vec<Field>, grammar: &Grammar, label: Option<&String>, r
             }
             // FIXME: This desperately needs better diagnostics.
             // There is no clue about which rule is causing the error.
-            panic!("unhandled Rule::Rep (repeated with '*'): {:?}\nInner: {:?}", rule, inner)
+            panic!(
+                "unhandled Rule::Rep (repeated with '*'): {:?}\nInner: {:?}",
+                rule, inner
+            )
         }
-         // Labeled { label: String, rule: Box<Rule>}
+        // Labeled { label: String, rule: Box<Rule>}
         //     A labeled rule, like `a:B` (`"a"` is the label, `B` is the rule).
         Rule::Labeled { label: l, rule } => {
             assert!(label.is_none());
@@ -822,8 +881,14 @@ fn lower_comma_list(
         _ => return false,
     }
     let ty = grammar[*node].name.clone();
-    let name = label.cloned().unwrap_or_else(|| pluralize(&to_lower_snake_case(&ty)));
-    let field = Field::Node { name, ty, cardinality: Cardinality::Many };
+    let name = label
+        .cloned()
+        .unwrap_or_else(|| pluralize(&to_lower_snake_case(&ty)));
+    let field = Field::Node {
+        name,
+        ty,
+        cardinality: Cardinality::Many,
+    };
     acc.push(field);
     true
 }
@@ -859,7 +924,11 @@ fn extract_enums(ast: &mut AstSrc) {
                 node.remove_field(to_remove);
                 let ty = enm.name.clone();
                 let name = to_lower_snake_case(&ty);
-                node.fields.push(Field::Node { name, ty, cardinality: Cardinality::Optional });
+                node.fields.push(Field::Node {
+                    name,
+                    ty,
+                    cardinality: Cardinality::Optional,
+                });
             }
         }
     }
@@ -869,11 +938,11 @@ fn extract_struct_traits(ast: &mut AstSrc) {
     let traits: &[(&str, &[&str])] = &[
         ("HasAttrs", &["attrs"]),
         ("HasName", &["name"]),
-//        ("HasTypeBounds", &["type_bound_list", "colon_token"]),
+        //        ("HasTypeBounds", &["type_bound_list", "colon_token"]),
         ("HasModuleItem", &["items"]),
         ("HasLoopBody", &["label", "loop_body"]),
         ("HasArgList", &["arg_list"]),
-//        ("HasGateArgList", &["gate_arg_list"]),
+        //        ("HasGateArgList", &["gate_arg_list"]),
     ];
 
     for node in &mut ast.nodes {

--- a/crates/oq3_syntax/src/validation.rs
+++ b/crates/oq3_syntax/src/validation.rs
@@ -6,15 +6,14 @@
 
 mod block;
 //mod lexer;
-pub use parser::{T};
+pub use parser::T;
 
 //use rowan::Direction;
 use lexer::unescape::{self, unescape_literal, Mode};
 
 use crate::{
     ast::{self, IsString},
-    match_ast, AstNode, SyntaxError,
-    SyntaxNode, TextSize
+    match_ast, AstNode, SyntaxError, SyntaxNode, TextSize,
 };
 
 // FIXME: GJL, I think I disabled many of these. Some should be used.
@@ -116,7 +115,8 @@ fn oq3_unescape_error_to_string(err: unescape::EscapeError) -> (&'static str, bo
 fn validate_literal(literal: ast::Literal, acc: &mut Vec<SyntaxError>) {
     // FIXME: move this function to outer scope (https://github.com/rust-lang/rust-analyzer/pull/2834#discussion_r366196658)
     fn unquote(text: &str, prefix_len: usize, end_delimiter: char) -> Option<&str> {
-        text.rfind(end_delimiter).and_then(|end| text.get(prefix_len..end))
+        text.rfind(end_delimiter)
+            .and_then(|end| text.get(prefix_len..end))
     }
 
     let token = literal.token();
@@ -172,10 +172,10 @@ fn validate_literal(literal: ast::Literal, acc: &mut Vec<SyntaxError>) {
             }
         }
         ast::LiteralKind::IntNumber(_)
-            | ast::LiteralKind::FloatNumber(_)
-            | ast::LiteralKind::TimingFloatNumber(_)
-            | ast::LiteralKind::SimpleFloatNumber(_)
-            | ast::LiteralKind::Bool(_) => {}
+        | ast::LiteralKind::FloatNumber(_)
+        | ast::LiteralKind::TimingFloatNumber(_)
+        | ast::LiteralKind::SimpleFloatNumber(_)
+        | ast::LiteralKind::Bool(_) => {}
     }
 }
 
@@ -208,5 +208,3 @@ fn _validate_block_structure(root: &SyntaxNode) {
         }
     }
 }
-
-

--- a/crates/parser/src/event.rs
+++ b/crates/parser/src/event.rs
@@ -72,10 +72,7 @@ pub(crate) enum Event {
     /// `n_raw_tokens` is used to glue complex contextual tokens.
     /// For example, lexer tokenizes `>>` as `>`, `>`, and
     /// `n_raw_tokens = 2` is used to produced a single `>>`.
-    Token {
-        kind: SyntaxKind,
-        n_raw_tokens: u8,
-    },
+    Token { kind: SyntaxKind, n_raw_tokens: u8 },
     /// When we parse `foo.0.0` or `foo. 0. 0` the lexer will hand us a float literal
     /// instead of an integer literal followed by a dot as the lexer has no contextual knowledge.
     /// This event instructs whatever consumes the events to split the float literal into
@@ -83,14 +80,15 @@ pub(crate) enum Event {
     // FloatSplitHack {
     //     ends_in_dot: bool,
     // },
-    Error {
-        msg: String,
-    },
+    Error { msg: String },
 }
 
 impl Event {
     pub(crate) fn tombstone() -> Self {
-        Event::Start { kind: TOMBSTONE, forward_parent: None }
+        Event::Start {
+            kind: TOMBSTONE,
+            forward_parent: None,
+        }
     }
 }
 
@@ -101,7 +99,10 @@ pub(super) fn process(mut events: Vec<Event>) -> Output {
 
     for i in 0..events.len() {
         match mem::replace(&mut events[i], Event::tombstone()) {
-            Event::Start { kind, forward_parent } => {
+            Event::Start {
+                kind,
+                forward_parent,
+            } => {
                 // For events[A, B, C], B is A's forward_parent, C is B's forward_parent,
                 // in the normal control flow, the parent-child relation: `A -> B -> C`,
                 // while with the magic forward_parent, it writes: `C <- B <- A`.
@@ -114,7 +115,10 @@ pub(super) fn process(mut events: Vec<Event>) -> Output {
                     idx += fwd as usize;
                     // append `A`'s forward_parent `B`
                     fp = match mem::replace(&mut events[idx], Event::tombstone()) {
-                        Event::Start { kind, forward_parent } => {
+                        Event::Start {
+                            kind,
+                            forward_parent,
+                        } => {
                             forward_parents.push(kind);
                             forward_parent
                         }

--- a/crates/parser/src/grammar.rs
+++ b/crates/parser/src/grammar.rs
@@ -71,7 +71,6 @@ pub(crate) mod entry {
             }
             m.complete(p, ERROR);
         }
-
     }
 }
 
@@ -89,8 +88,8 @@ impl BlockLike {
     }
 
     fn is_blocklike(kind: SyntaxKind) -> bool {
-        matches!(kind, BLOCK_EXPR )
-//        matches!(kind, BLOCK_EXPR | IF_EXPR | WHILE_EXPR | FOR_EXPR)
+        matches!(kind, BLOCK_EXPR)
+        //        matches!(kind, BLOCK_EXPR | IF_EXPR | WHILE_EXPR | FOR_EXPR)
     }
 }
 
@@ -125,7 +124,6 @@ fn opt_ret_type(p: &mut Parser<'_>) -> bool {
 /// Parse an identifer signifying a name. Attempt recovery
 /// on failure.
 fn name_r(p: &mut Parser<'_>, recovery: TokenSet) {
-
     // FIXME: testing. dont know if this belongs
     if p.at(HARDWAREIDENT) {
         let m = p.start();

--- a/crates/parser/src/grammar/expressions/atom.rs
+++ b/crates/parser/src/grammar/expressions/atom.rs
@@ -5,8 +5,7 @@ use super::*;
 use crate::grammar;
 use crate::grammar::expressions;
 
-pub(crate) const PATH_FIRST: TokenSet =
-    TokenSet::new(&[IDENT, HARDWAREIDENT, T![:], T![<]]);
+pub(crate) const PATH_FIRST: TokenSet = TokenSet::new(&[IDENT, HARDWAREIDENT, T![:], T![<]]);
 
 pub(crate) const LITERAL_FIRST: TokenSet = TokenSet::new(&[
     T![true],
@@ -70,7 +69,7 @@ pub(super) fn atom_expr(
         // Ugh. this is needed for `int[32]` for example. But it prevents array indexing `v[1:3]` from working
         // Need to distinguish these
         T!['['] => array_expr(p),
-//        T![if] => if_expr(p),
+        //        T![if] => if_expr(p),
         T![box] => box_expr(p, None),
         //        T![while] => while_expr(p, None),
         T![measure] => measure_expression(p),
@@ -79,8 +78,8 @@ pub(super) fn atom_expr(
         T![for] => for_expr(p, None),
         // FIXME: This is the simplest gate call. Need to cover
         // `mygate(myparam) q1, q2;` as well.
-//        IDENT if la == IDENT => gate_call_expr(p),
-        IDENT if (la == T![=] && p.nth(2) != T![=])  => grammar::items::assignment_statement(p),
+        //        IDENT if la == IDENT => gate_call_expr(p),
+        IDENT if (la == T![=] && p.nth(2) != T![=]) => grammar::items::assignment_statement(p),
         // FIXME: An identifer bound by the user in the program.
         // Need to handle more than identifier.
         // Also `NAME` is probably not correct.
@@ -90,8 +89,11 @@ pub(super) fn atom_expr(
             return None;
         }
     };
-    let blocklike =
-        if BlockLike::is_blocklike(done.kind()) { BlockLike::Block } else { BlockLike::NotBlock };
+    let blocklike = if BlockLike::is_blocklike(done.kind()) {
+        BlockLike::Block
+    } else {
+        BlockLike::NotBlock
+    };
     Some((done, blocklike))
 }
 
@@ -110,7 +112,6 @@ fn measure_expression(p: &mut Parser<'_>) -> CompletedMarker {
     }
     m.complete(p, MEASURE_EXPRESSION)
 }
-
 
 // FIXME: changed the kind to `NAME`
 // FIXME: changed it back to IDENTIFIER
@@ -152,7 +153,14 @@ fn tuple_expr(p: &mut Parser<'_>) -> CompletedMarker {
         }
     }
     p.expect(T![')']);
-    m.complete(p, if saw_expr && !saw_comma { PAREN_EXPR } else { TUPLE_EXPR })
+    m.complete(
+        p,
+        if saw_expr && !saw_comma {
+            PAREN_EXPR
+        } else {
+            TUPLE_EXPR
+        },
+    )
 }
 
 fn array_expr(p: &mut Parser<'_>) -> CompletedMarker {

--- a/crates/parser/src/grammar/items.rs
+++ b/crates/parser/src/grammar/items.rs
@@ -1,8 +1,7 @@
 // Copyright contributors to the openqasm-parser project
 
-use crate::grammar::expressions::expr_block_contents;
 use super::*;
-
+use crate::grammar::expressions::expr_block_contents;
 
 // This is more or less the entry point for the parser crate.
 // Entry point `fn parse` in lib.rs calls grammar::entry::top::source_file.
@@ -21,7 +20,7 @@ pub(super) const ITEM_RECOVERY_SET: TokenSet = TokenSet::new(&[
     T![include],
     T![cal],
     T![reset],
-//    T![measure],
+    //    T![measure],
     T![barrier],
     T![const],
     T![let],
@@ -48,10 +47,8 @@ pub(super) fn item(p: &mut Parser<'_>, stop_on_r_curly: bool) {
                 );
             }
             return;
-        },
-        Err(m) => {
-            m
         }
+        Err(m) => m,
     };
     match p.current() {
         T!['}'] if !stop_on_r_curly => {
@@ -61,7 +58,10 @@ pub(super) fn item(p: &mut Parser<'_>, stop_on_r_curly: bool) {
             p.bump(T!['}']);
             e.complete(p, ERROR);
         }
-        EOF | T!['}'] => {m.abandon(p); p.error("expected an item GJL 2")},
+        EOF | T!['}'] => {
+            m.abandon(p);
+            p.error("expected an item GJL 2")
+        }
         // Parse (semicolon terminated) statements until EOF or '}'.
         // I'm pretty sure there is no open '{' at this point, so this means stop at EOF only.
         // FIXME: for this reason, perhaps recursively call `fn item` instead.
@@ -70,7 +70,7 @@ pub(super) fn item(p: &mut Parser<'_>, stop_on_r_curly: bool) {
             expr_block_contents(p);
         }
     }
-//    }
+    //    }
 }
 
 /// Try to parse an item, completing `m` in case of success.
@@ -81,7 +81,7 @@ pub(super) fn opt_item(p: &mut Parser<'_>, m: Marker) -> Result<(), Marker> {
     let la = p.nth(1);
     if p.current().is_classical_type() && la != T!['('] {
         expressions::classical_declaration_stmt(p, m);
-        return Ok(())
+        return Ok(());
     };
     // if p.at(HARDWAREIDENT) {
     //     p.bump(HARDWAREIDENT);
@@ -97,41 +97,41 @@ pub(super) fn opt_item(p: &mut Parser<'_>, m: Marker) -> Result<(), Marker> {
     //     }
     // } else {
 
-        match p.current() {
-            T![qubit] => qubit_declaration_stmt(p, m),
-            T![const] => expressions::classical_declaration_stmt(p, m),
-            IDENT if (la == IDENT || la == HARDWAREIDENT) => gate_call_stmt(p, m),
-            IDENT if (la == T![=] && p.nth(2) != T![=]) => assignment_statement_with_marker(p, m),
-            T![gate] => gate_definition(p, m),
-            T![break] => break_(p, m),
-            T![continue] => continue_(p, m),
-            T![end] => end_(p, m),
-            T![if] => if_stmt(p, m),
-            T![while] => while_stmt(p, m),
-            T![def] => def_(p, m),
-            T![defcal] => defcal_(p, m),
-            T![cal] => cal_(p, m),
-            T![defcalgrammar] => defcalgrammar_(p, m),
-            T![reset] => reset_(p, m),
-            // measure is not a statement, does not belong here.
-//            T![measure] => measure_(p, m),
-            T![barrier] => barrier_(p, m),
-            T![OPENQASM] => version_string(p, m),
-            T![include] => include(p, m),
-            T![gphase] =>  gphase_call(p, m),
-            // This is already done elsewhere
-            //            T![let] => let_stmt(p, m),
-            _ => return Err(m),
-        }
+    match p.current() {
+        T![qubit] => qubit_declaration_stmt(p, m),
+        T![const] => expressions::classical_declaration_stmt(p, m),
+        IDENT if (la == IDENT || la == HARDWAREIDENT) => gate_call_stmt(p, m),
+        IDENT if (la == T![=] && p.nth(2) != T![=]) => assignment_statement_with_marker(p, m),
+        T![gate] => gate_definition(p, m),
+        T![break] => break_(p, m),
+        T![continue] => continue_(p, m),
+        T![end] => end_(p, m),
+        T![if] => if_stmt(p, m),
+        T![while] => while_stmt(p, m),
+        T![def] => def_(p, m),
+        T![defcal] => defcal_(p, m),
+        T![cal] => cal_(p, m),
+        T![defcalgrammar] => defcalgrammar_(p, m),
+        T![reset] => reset_(p, m),
+        // measure is not a statement, does not belong here.
+        //            T![measure] => measure_(p, m),
+        T![barrier] => barrier_(p, m),
+        T![OPENQASM] => version_string(p, m),
+        T![include] => include(p, m),
+        T![gphase] => gphase_call(p, m),
+        // This is already done elsewhere
+        //            T![let] => let_stmt(p, m),
+        _ => return Err(m),
+    }
     Ok(())
 }
 
 // expressions::call_expr also handles some occurences of gate calls
 // FIXME: params in parens are likely always caught in expressions::call_expr
 fn gate_call_stmt(p: &mut Parser<'_>, m: Marker) {
-//    expressions::var_name(p);
+    //    expressions::var_name(p);
     expressions::atom::identifier(p); // name of gate
-    assert!(! p.at(T!['(']));
+    assert!(!p.at(T!['(']));
     // This is never true, I hope
     if p.at(T!['(']) {
         expressions::call_arg_list(p);
@@ -151,7 +151,7 @@ fn gphase_call(p: &mut Parser<'_>, m: Marker) {
 
 fn if_stmt(p: &mut Parser<'_>, m: Marker) {
     assert!(p.at(T![if]));
-//    let m = p.start();
+    //    let m = p.start();
     p.bump(T![if]);
     expressions::expr_no_struct(p);
     expressions::block_expr(p);
@@ -239,11 +239,11 @@ pub(crate) fn ident_or_index_expr(p: &mut Parser<'_>) {
                     m.complete(p, IDENT);
                 }
             }
-        },
+        }
         HARDWAREIDENT => {
             p.bump(HARDWAREIDENT);
             m.complete(p, HARDWARE_QUBIT);
-        },
+        }
         _ => panic!(),
     }
 }
@@ -401,8 +401,8 @@ fn version_string(p: &mut Parser<'_>, m: Marker) {
 
 fn version_(p: &mut Parser<'_>) -> bool {
     let m = p.start();
-//    if ! p.expect(SIMPLE_FLOAT_NUMBER) && ! p.at(SEMICOLON) {
-    if ! p.expect(FLOAT_NUMBER) && ! p.at(SEMICOLON) {
+    //    if ! p.expect(SIMPLE_FLOAT_NUMBER) && ! p.at(SEMICOLON) {
+    if !p.expect(FLOAT_NUMBER) && !p.at(SEMICOLON) {
         p.bump_any(); // FIXME eat til semicolon
     }
     p.expect(SEMICOLON);

--- a/crates/parser/src/grammar/params.rs
+++ b/crates/parser/src/grammar/params.rs
@@ -61,14 +61,14 @@ enum DefFlavor {
     // Same syntax for: gate def params, function call params, gate call params.
     // But for various reasons, we separate this into GateParams and CallOrGateCallParams
     // One reason: we can disallow here empty parens in gate def.
-    GateParams,   // parens,    no type
+    GateParams, // parens,    no type
     // For the moment, following is handled in expressions::arg_list instead.
-    GateQubits,   // no parens, no type, '{' terminates
-    GateCallQubits,   // no parens, no type, ';' terminates
-    DefParams,    // parens,    type
-    DefCalParams, // parens,    opt type
-    DefCalQubits, // no parens, no type, '{' or '->' terminates
-//    SetExpression,
+    GateQubits,     // no parens, no type, '{' terminates
+    GateCallQubits, // no parens, no type, ';' terminates
+    DefParams,      // parens,    type
+    DefCalParams,   // parens,    opt type
+    DefCalQubits,   // no parens, no type, '{' or '->' terminates
+    //    SetExpression,
     ExpressionList,
 }
 
@@ -80,7 +80,7 @@ fn _param_list_openqasm(p: &mut Parser<'_>, flavor: DefFlavor, m: Option<Marker>
     let want_parens = matches!(flavor, GateParams | DefParams | DefCalParams);
     match flavor {
         GateParams | DefParams | DefCalParams => p.bump(T!['(']),
-//        SetExpression => p.bump(T!['{']),
+        //        SetExpression => p.bump(T!['{']),
         _ => (),
     }
     // FIXME: find implementation that does not require [T![')'], T![')']]
@@ -96,7 +96,7 @@ fn _param_list_openqasm(p: &mut Parser<'_>, flavor: DefFlavor, m: Option<Marker>
         GateQubits => [T!['{'], T!['{']],
         GateCallQubits => [SEMICOLON, SEMICOLON],
         DefCalQubits => [T!['{'], T![->]],
-//        SetExpression => [T!['}'], T!['}']],
+        //        SetExpression => [T!['}'], T!['}']],
     };
     let mut param_marker = m;
     // let mut param_marker = None;
@@ -114,14 +114,15 @@ fn _param_list_openqasm(p: &mut Parser<'_>, flavor: DefFlavor, m: Option<Marker>
         let found_param = match flavor {
             ExpressionList => {
                 m.abandon(p);
-                expressions::expr_or_range_expr(p); true
-            },
-//            SetExpression => { m.abandon(p); expressions::expr(p); true }
-            GateCallQubits => {arg_gate_call_qubit(p, m)}
-            DefParams | DefCalParams => {param_typed(p, m)}
-            _ => {param_untyped(p, m)}
+                expressions::expr_or_range_expr(p);
+                true
+            }
+            //            SetExpression => { m.abandon(p); expressions::expr(p); true }
+            GateCallQubits => arg_gate_call_qubit(p, m),
+            DefParams | DefCalParams => param_typed(p, m),
+            _ => param_untyped(p, m),
         };
-        if ! found_param {
+        if !found_param {
             break;
         }
         num_params += 1;
@@ -129,7 +130,7 @@ fn _param_list_openqasm(p: &mut Parser<'_>, flavor: DefFlavor, m: Option<Marker>
         // Not for `{`. But I don't know why. prbly because `->` is compound.
         // FIXME: use at_ts()
         if list_end_tokens.iter().any(|x| p.at(*x)) {
-//        if p.at_ts(list_end_tokens) {
+            //        if p.at_ts(list_end_tokens) {
             break;
         }
         // Params must be separated by commas.
@@ -162,7 +163,7 @@ fn _param_list_openqasm(p: &mut Parser<'_>, flavor: DefFlavor, m: Option<Marker>
     //     p.expect(T!['}']);
     // }
     let kind = match flavor {
-//        SetExpression => SET_EXPRESSION,
+        //        SetExpression => SET_EXPRESSION,
         GateQubits => PARAM_LIST,
         DefCalQubits => QUBIT_LIST,
         GateCallQubits => QUBIT_LIST,
@@ -174,8 +175,9 @@ fn _param_list_openqasm(p: &mut Parser<'_>, flavor: DefFlavor, m: Option<Marker>
     // list_marker.complete(p, if is_qubits {QUBIT_LIST} else {PARAM_LIST});
 }
 
-const PATTERN_FIRST: TokenSet =
-    expressions::LITERAL_FIRST.union(expressions::atom::PATH_FIRST).union(TokenSet::new(&[
+const PATTERN_FIRST: TokenSet = expressions::LITERAL_FIRST
+    .union(expressions::atom::PATH_FIRST)
+    .union(TokenSet::new(&[
         T![box],
         T![const],
         T!['('],
@@ -224,7 +226,7 @@ fn param_typed(p: &mut Parser<'_>, m: Marker) -> bool {
     if !p.at(IDENT) {
         p.error("expected parameter name");
         m.abandon(p);
-        return false
+        return false;
     }
     p.bump(IDENT);
     m.complete(p, PARAM);
@@ -235,7 +237,7 @@ fn arg_gate_call_qubit(p: &mut Parser<'_>, m: Marker) -> bool {
     if p.at(HARDWAREIDENT) {
         p.bump(HARDWAREIDENT);
         m.complete(p, HARDWARE_QUBIT);
-        return true
+        return true;
     }
 
     if !p.at(IDENT) {
@@ -243,11 +245,11 @@ fn arg_gate_call_qubit(p: &mut Parser<'_>, m: Marker) -> bool {
         m.abandon(p);
         return false;
     }
-//    let mcomp = expressions::atom::identifier(p);
+    //    let mcomp = expressions::atom::identifier(p);
     p.bump(IDENT);
     let mcomp = m.complete(p, IDENTIFIER);
     if p.at(T!['[']) {
-//        expressions::index_expr(p, mcomp);
+        //        expressions::index_expr(p, mcomp);
         expressions::indexed_identifer(p, mcomp);
         return true;
     }

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -6,13 +6,13 @@ mod lexed_str;
 mod token_set;
 
 // Temp make pub for debugging
-pub mod syntax_kind;
 mod event;
-mod parser;
 mod grammar;
 mod input;
 mod output;
+mod parser;
 mod shortcuts;
+pub mod syntax_kind;
 
 // FIXME
 // #[cfg(test)]
@@ -36,7 +36,7 @@ pub use crate::{
 #[derive(Debug)]
 pub enum TopEntryPoint {
     SourceFile,
-//    Type,
+    //    Type,
     Expr,
 }
 
@@ -44,7 +44,7 @@ impl TopEntryPoint {
     pub fn parse(&self, input: &Input) -> Output {
         let entry_point: fn(&'_ mut parser::Parser<'_>) = match self {
             TopEntryPoint::SourceFile => grammar::entry::top::source_file,
-//            TopEntryPoint::Type => grammar::entry::top::type_,
+            //            TopEntryPoint::Type => grammar::entry::top::type_,
             TopEntryPoint::Expr => grammar::entry::top::expr,
         };
         let mut p = parser::Parser::new(input);
@@ -61,9 +61,9 @@ impl TopEntryPoint {
                 match step {
                     Step::Enter { .. } => depth += 1,
                     Step::Exit => depth -= 1,
-                    Step::FloatSplit { ends_in_dot: has_pseudo_dot } => {
-                        depth -= 1 + !has_pseudo_dot as usize
-                    }
+                    Step::FloatSplit {
+                        ends_in_dot: has_pseudo_dot,
+                    } => depth -= 1 + !has_pseudo_dot as usize,
                     Step::Token { .. } | Step::Error { .. } => (),
                 }
             }

--- a/crates/parser/src/output.rs
+++ b/crates/parser/src/output.rs
@@ -26,11 +26,20 @@ pub struct Output {
 
 #[derive(Debug)]
 pub enum Step<'a> {
-    Token { kind: SyntaxKind, n_input_tokens: u8 },
-    FloatSplit { ends_in_dot: bool },
-    Enter { kind: SyntaxKind },
+    Token {
+        kind: SyntaxKind,
+        n_input_tokens: u8,
+    },
+    FloatSplit {
+        ends_in_dot: bool,
+    },
+    Enter {
+        kind: SyntaxKind,
+    },
     Exit,
-    Error { msg: &'a str },
+    Error {
+        msg: &'a str,
+    },
 }
 
 impl Output {
@@ -63,7 +72,10 @@ impl Output {
                         (((event & Self::KIND_MASK) >> Self::KIND_SHIFT) as u16).into();
                     let n_input_tokens =
                         ((event & Self::N_INPUT_TOKEN_MASK) >> Self::N_INPUT_TOKEN_SHIFT) as u8;
-                    Step::Token { kind, n_input_tokens }
+                    Step::Token {
+                        kind,
+                        n_input_tokens,
+                    }
                 }
                 Self::ENTER_EVENT => {
                     let kind: SyntaxKind =
@@ -71,9 +83,9 @@ impl Output {
                     Step::Enter { kind }
                 }
                 Self::EXIT_EVENT => Step::Exit,
-                Self::SPLIT_EVENT => {
-                    Step::FloatSplit { ends_in_dot: event & Self::N_INPUT_TOKEN_MASK != 0 }
-                }
+                Self::SPLIT_EVENT => Step::FloatSplit {
+                    ends_in_dot: event & Self::N_INPUT_TOKEN_MASK != 0,
+                },
                 _ => unreachable!(),
             }
         })

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -25,7 +25,7 @@ use crate::{
 /// finish expression". See `Event` docs for more.
 pub(crate) struct Parser<'t> {
     inp: &'t Input,
-    pos: usize,  // Ordinal token number
+    pos: usize, // Ordinal token number
     events: Vec<Event>,
     steps: Cell<u32>,
 }
@@ -34,7 +34,12 @@ static PARSER_STEP_LIMIT: Limit = Limit::new(15_000_000);
 
 impl<'t> Parser<'t> {
     pub(super) fn new(inp: &'t Input) -> Parser<'t> {
-        Parser { inp, pos: 0, events: Vec::new(), steps: Cell::new(0) }
+        Parser {
+            inp,
+            pos: 0,
+            events: Vec::new(),
+            steps: Cell::new(0),
+        }
     }
 
     pub(crate) fn finish(self) -> Vec<Event> {
@@ -66,7 +71,10 @@ impl<'t> Parser<'t> {
         assert!(n <= 3);
 
         let steps = self.steps.get();
-        assert!(PARSER_STEP_LIMIT.check(steps as usize).is_ok(), "the parser seems stuck");
+        assert!(
+            PARSER_STEP_LIMIT.check(steps as usize).is_ok(),
+            "the parser seems stuck"
+        );
         self.steps.set(steps + 1);
 
         self.inp.kind(self.pos + n)
@@ -247,7 +255,7 @@ impl<'t> Parser<'t> {
         if self.eat(kind) {
             return true;
         }
-//        println!("------------ will error with 'expected {kind:?}"); // GJL debug
+        //        println!("------------ will error with 'expected {kind:?}"); // GJL debug
         self.error(format!("expected {kind:?}"));
         false
     }
@@ -304,7 +312,10 @@ pub(crate) struct Marker {
 
 impl Marker {
     fn new(pos: u32) -> Marker {
-        Marker { pos, bomb: DropBomb::new("Marker must be either completed or abandoned") }
+        Marker {
+            pos,
+            bomb: DropBomb::new("Marker must be either completed or abandoned"),
+        }
     }
 
     /// Finishes the syntax tree node and assigns `kind` to it,
@@ -330,7 +341,10 @@ impl Marker {
         let idx = self.pos as usize;
         if idx == p.events.len() - 1 {
             match p.events.pop() {
-                Some(Event::Start { kind: TOMBSTONE, forward_parent: None }) => (),
+                Some(Event::Start {
+                    kind: TOMBSTONE,
+                    forward_parent: None,
+                }) => (),
                 _ => unreachable!(),
             }
         }

--- a/crates/parser/src/token_set.rs
+++ b/crates/parser/src/token_set.rs
@@ -34,7 +34,6 @@ const fn mask(kind: SyntaxKind) -> u128 {
     1u128 << (kind as usize)
 }
 
-
 #[test]
 fn token_set_works_for_tokens() {
     use crate::SyntaxKind::*;

--- a/crates/qasm3_bytecode/src/bytecode.rs
+++ b/crates/qasm3_bytecode/src/bytecode.rs
@@ -1,12 +1,8 @@
 // Copyright contributors to the openqasm-parser project
 
 // use semantics::asg;
-use semantics::asg::{
-    TExpr, GateModifier
-};
-use semantics::symbols::{
-    SymbolId,
-};
+use semantics::asg::{GateModifier, TExpr};
+use semantics::symbols::SymbolId;
 
 #[derive(Clone)]
 pub enum ByteCode {
@@ -26,5 +22,5 @@ pub struct GateCall {
 
 #[derive(Clone)]
 pub struct DeclareQuantum {
-    name: SymbolId
+    name: SymbolId,
 }

--- a/crates/qasm3_bytecode/src/lib.rs
+++ b/crates/qasm3_bytecode/src/lib.rs
@@ -13,13 +13,13 @@
 //! a bug in the the upstream code, but is not a bug in these wrappers.
 
 use pyo3::prelude::*;
-use pyo3::Python;
 use pyo3::wrap_pymodule;
+use pyo3::Python;
 
-mod semanticpy;
-mod parse;
 mod bytecode;
+mod parse;
 mod pybytecode;
+mod semanticpy;
 mod to_pybytecode;
 
 #[pymodule]

--- a/crates/qasm3_bytecode/src/parse.rs
+++ b/crates/qasm3_bytecode/src/parse.rs
@@ -1,12 +1,12 @@
 // Copyright contributors to the openqasm-parser project
 
-use pyo3::Python;
 use pyo3::prelude::*;
+use pyo3::Python;
 
 //use std::fs; // for reading file
-use std::path::PathBuf;
 use semantics::asg;
 use semantics::symbols;
+use std::path::PathBuf;
 //use semantics::syntax_to_semantics as synsem;
 // use semantics::syntax_to_semantics::{
 //     string_to_semantic

--- a/crates/qasm3_bytecode/src/pybytecode.rs
+++ b/crates/qasm3_bytecode/src/pybytecode.rs
@@ -1,7 +1,7 @@
 // Copyright contributors to the openqasm-parser project
 
-use pyo3::Python;
 use pyo3::prelude::*;
+use pyo3::Python;
 
 #[pyclass(frozen)]
 #[derive(Clone)]
@@ -20,5 +20,5 @@ pub enum OpCode {
     DeclareQreg,
     BlockStart,
     BlockEnd,
-//    DeclareQubit,
+    //    DeclareQubit,
 }

--- a/crates/qasm3_bytecode/src/semanticpy.rs
+++ b/crates/qasm3_bytecode/src/semanticpy.rs
@@ -1,12 +1,11 @@
 // Copyright contributors to the openqasm-parser project
 
 use pyo3::prelude::*;
-use pyo3::Python;
 use pyo3::types::PyList;
+use pyo3::Python;
 
-use semantics::{asg, types, symbols};
+use semantics::{asg, symbols, types};
 use symbols::SymbolType; // trait for getting symbol type
-
 
 #[derive(Clone)]
 #[pyclass]
@@ -32,7 +31,7 @@ pub enum TypeName {
     BoolArray,
     DurationArray,
     // Other
-    Gate, // <-- this type seems anomalous
+    Gate,  // <-- this type seems anomalous
     Range, // temporary placeholder, perhaps
     Void,
     Invalid,
@@ -62,7 +61,7 @@ impl Type {
             At::Angle(..) => Tn::Angle,
             At::Gate => Tn::Gate,
             At::QubitArray(..) => Tn::QubitArray,
-            _ => TypeName::NotImplemented // TODO: all other types
+            _ => TypeName::NotImplemented, // TODO: all other types
         }
     }
 
@@ -86,14 +85,13 @@ impl Type {
 //     }
 // }
 
-
 #[pyclass]
 #[derive(Clone)]
 pub struct TExpr(asg::TExpr);
 
 #[pymethods]
 impl TExpr {
-//impl TExpr<'_> {
+    //impl TExpr<'_> {
     pub fn get_type(&self) -> Type {
         Type(self.0.get_type().clone())
     }
@@ -120,10 +118,9 @@ impl DeclareClassical {
     pub fn initializer(&self, py: Python<'_>) -> PyObject {
         match self.0.initializer() {
             Some(expr) => Expr(expr.as_ref().expression()).into_py(py),
-            None => py.None()
+            None => py.None(),
         }
     }
-
 }
 
 #[pyclass]
@@ -164,10 +161,14 @@ impl GateCall {
     }
 
     pub fn qubits(&self, py: Python<'_>) -> Py<PyList> {
-        let elements: Vec<_> = self.0.qubits().iter().map(|x| TExpr(x.clone()).into_py(py)).collect();
+        let elements: Vec<_> = self
+            .0
+            .qubits()
+            .iter()
+            .map(|x| TExpr(x.clone()).into_py(py))
+            .collect();
         PyList::new(py, elements).into()
     }
-
 }
 // wrapper exists only allow `impl IntoPy for Stmt`
 #[derive(Clone)]
@@ -179,7 +180,7 @@ impl IntoPy<PyObject> for Stmt {
             asg::Stmt::DeclareQuantum(qdecl) => DeclareQuantum(qdecl).into_py(py),
             asg::Stmt::DeclareClassical(cdecl) => DeclareClassical(cdecl).into_py(py),
             asg::Stmt::GateCall(gate_call) => GateCall(gate_call).into_py(py),
-            _ => py.None()
+            _ => py.None(),
         }
     }
 }
@@ -196,7 +197,12 @@ impl Program {
     }
 
     pub fn statements(&self, py: Python<'_>) -> Py<PyList> {
-        let elements: Vec<_> = self.0.stmts.iter().map(|x| Stmt(x.clone()).into_py(py)).collect();
+        let elements: Vec<_> = self
+            .0
+            .stmts
+            .iter()
+            .map(|x| Stmt(x.clone()).into_py(py))
+            .collect();
         PyList::new(py, elements).into()
     }
 }
@@ -222,13 +228,13 @@ impl IntoPy<PyObject> for Expr<'_> {
         match self.0 {
             asg::Expr::Literal(asg::Literal::Bool(bool_literal)) => {
                 BoolLiteral(bool_literal.clone()).into_py(py)
-            },
-            asg::Expr::GateOperand(asg::GateOperand::Identifier(ident)) => {
-//                dbg!(ident.clone());
-                SymbolId(ident.clone().symbol().as_ref().unwrap().clone()).into_py(py)
-//                py.None()
             }
-            _ => py.None()
+            asg::Expr::GateOperand(asg::GateOperand::Identifier(ident)) => {
+                //                dbg!(ident.clone());
+                SymbolId(ident.clone().symbol().as_ref().unwrap().clone()).into_py(py)
+                //                py.None()
+            }
+            _ => py.None(),
         }
     }
 }
@@ -238,7 +244,7 @@ impl IntoPy<PyObject> for Expr<'_> {
 pub struct Symbol(pub symbols::Symbol);
 
 use pyo3::class::basic::CompareOp;
-use pyo3::exceptions::{PyTypeError};
+use pyo3::exceptions::PyTypeError;
 
 #[pymethods]
 impl SymbolId {
@@ -253,7 +259,9 @@ impl SymbolId {
         match op {
             CompareOp::Eq => Ok(self.0 == other.0),
             CompareOp::Ne => Ok(self.0 != other.0),
-            _ => Err(PyTypeError::new_err(format!("Operation {op:?} not supported")))
+            _ => Err(PyTypeError::new_err(format!(
+                "Operation {op:?} not supported"
+            ))),
         }
     }
 }
@@ -277,16 +285,14 @@ impl Symbol {
     }
 }
 
-
 #[pyclass]
 #[derive(Clone)]
 pub struct SymbolTable(pub symbols::SymbolTable);
 
-
 #[pymethods]
 impl SymbolTable {
-//    #[pyo3(name = "__item__")]
-    pub fn get_symbol(&self, symbol_id:SymbolId) -> Symbol {
+    //    #[pyo3(name = "__item__")]
+    pub fn get_symbol(&self, symbol_id: SymbolId) -> Symbol {
         Symbol(self.0[&symbol_id.0].clone())
     }
 }
@@ -315,9 +321,9 @@ pub fn check_enum(x: TypeName, py: Python<'_>) -> PyObject {
     match x {
         TypeName::Int => 1i32,
         _ => 0i32,
-    }.into_py(py)
+    }
+    .into_py(py)
 }
-
 
 // #[pyfunction]
 // pub fn cdeclaration(py: Python<'_>) -> (PyObject, SymbolTable) {

--- a/crates/semantics/src/semantic_error.rs
+++ b/crates/semantics/src/semantic_error.rs
@@ -6,7 +6,7 @@ use oq3_syntax::SyntaxNode;
 use source_file;
 use source_file::ErrorTrait;
 use std::fmt;
-use std::path::{PathBuf, Path};
+use std::path::{Path, PathBuf};
 
 // re-exported in lib.rs from rowan
 use crate::TextRange;

--- a/crates/semantics/src/symbols.rs
+++ b/crates/semantics/src/symbols.rs
@@ -5,7 +5,6 @@
 use crate::types::Type;
 use hashbrown::HashMap;
 
-
 // OQ3
 // * "The lifetime of each identifier begins when it is declared, and ends
 //    at the completion of the scope it was declared in."

--- a/crates/semantics/src/syntax_to_semantics.rs
+++ b/crates/semantics/src/syntax_to_semantics.rs
@@ -9,7 +9,7 @@
 
 use std;
 use std::mem::replace;
-use std::path::{PathBuf};
+use std::path::PathBuf;
 
 use crate::asg;
 use crate::types;

--- a/crates/semantics/src/validate.rs
+++ b/crates/semantics/src/validate.rs
@@ -3,8 +3,6 @@
 use crate::asg::{Expr, Program, Stmt, TExpr};
 use crate::symbols::{SymbolIdResult, SymbolTable};
 
-
-
 // Thus far, everything below is meant to apply any function
 // FnMut(&SymbolIdResult) to all possible places in the ASG.
 

--- a/crates/source_file/src/api.rs
+++ b/crates/source_file/src/api.rs
@@ -8,11 +8,11 @@ use ariadne::{ColorGenerator, Label, Report, ReportKind, Source};
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 
- // Syntactic AST
+// Syntactic AST
 
 use crate::source_file::{
-    expand_path, parse_source_and_includes, range_to_span, read_source_file,
-    ErrorTrait, Normalizeable, SourceFile, SourceString,
+    expand_path, parse_source_and_includes, range_to_span, read_source_file, ErrorTrait,
+    Normalizeable, SourceFile, SourceString,
 };
 
 /// Read source from `file_path` and parse to the syntactic AST.

--- a/crates/source_file/src/lib.rs
+++ b/crates/source_file/src/lib.rs
@@ -11,7 +11,6 @@
 mod api;
 mod source_file;
 
-
 pub use source_file::{ErrorTrait, SourceFile, SourceString, SourceTrait};
 
 pub use api::{

--- a/crates/source_file/src/source_file.rs
+++ b/crates/source_file/src/source_file.rs
@@ -6,14 +6,12 @@ use oq3_syntax::TextRange;
 use std::env;
 use std::ffi::OsStr;
 use std::fs;
-use std::path::{PathBuf, Path};
+use std::path::{Path, PathBuf};
 
 // traits
 use oq3_syntax::ast::HasModuleItem;
 
-use crate::api::{
-    inner_print_compiler_errors, parse_source_file, print_compiler_errors,
-};
+use crate::api::{inner_print_compiler_errors, parse_source_file, print_compiler_errors};
 
 pub(crate) fn parse_source_and_includes(source: &str) -> (ParsedSource, Vec<SourceFile>) {
     let syntax_ast: ParsedSource = synast::SourceFile::parse(source);

--- a/crates/sourcegen/src/lib.rs
+++ b/crates/sourcegen/src/lib.rs
@@ -13,7 +13,11 @@
 //!
 //! This crate contains utilities to make this kind of source-gen easy.
 
-#![warn(rust_2018_idioms, unused_lifetimes, semicolon_in_expressions_from_macros)]
+#![warn(
+    rust_2018_idioms,
+    unused_lifetimes,
+    semicolon_in_expressions_from_macros
+)]
 
 use std::{
     fmt, fs, mem,
@@ -28,7 +32,11 @@ use xshell::{cmd, Shell};
 pub fn list_rust_files(dir: &Path) -> Vec<PathBuf> {
     let mut res = list_files(dir);
     res.retain(|it| {
-        it.file_name().unwrap_or_default().to_str().unwrap_or_default().ends_with(".rs")
+        it.file_name()
+            .unwrap_or_default()
+            .to_str()
+            .unwrap_or_default()
+            .ends_with(".rs")
     });
     res
 }
@@ -41,8 +49,12 @@ pub fn list_files(dir: &Path) -> Vec<PathBuf> {
             let entry = entry.unwrap();
             let file_type = entry.file_type().unwrap();
             let path = entry.path();
-            let is_hidden =
-                path.file_name().unwrap_or_default().to_str().unwrap_or_default().starts_with('.');
+            let is_hidden = path
+                .file_name()
+                .unwrap_or_default()
+                .to_str()
+                .unwrap_or_default()
+                .starts_with('.');
             if !is_hidden {
                 if file_type.is_dir() {
                     work.push(path);
@@ -90,8 +102,12 @@ impl CommentBlock {
 
         let lines = text.lines().map(str::trim_start);
 
-        let dummy_block =
-            CommentBlock { id: String::new(), line: 0, contents: Vec::new(), is_doc: false };
+        let dummy_block = CommentBlock {
+            id: String::new(),
+            line: 0,
+            contents: Vec::new(),
+            is_doc: false,
+        };
         let mut block = dummy_block.clone();
         for (line_num, line) in lines.enumerate() {
             match line.strip_prefix("//") {
@@ -134,7 +150,12 @@ pub struct Location {
 // source is recorded so that the dev can find them.
 impl fmt::Display for Location {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let path = self.file.strip_prefix(project_root()).unwrap().display().to_string();
+        let path = self
+            .file
+            .strip_prefix(project_root())
+            .unwrap()
+            .display()
+            .to_string();
         let path = path.replace('\\', "/");
         let name = self.file.file_name().unwrap();
         write!(
@@ -148,7 +169,9 @@ impl fmt::Display for Location {
 }
 
 fn ensure_rustfmt(sh: &Shell) {
-    let version = cmd!(sh, "rustup run stable rustfmt --version").read().unwrap_or_default();
+    let version = cmd!(sh, "rustup run stable rustfmt --version")
+        .read()
+        .unwrap_or_default();
     if !version.contains("stable") {
         panic!(
             "Failed to run rustfmt from toolchain 'stable'. \
@@ -211,7 +234,12 @@ fn normalize_newlines(s: &str) -> String {
 
 pub fn project_root() -> PathBuf {
     let dir = env!("CARGO_MANIFEST_DIR");
-    let res = PathBuf::from(dir).parent().unwrap().parent().unwrap().to_owned();
+    let res = PathBuf::from(dir)
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_owned();
     assert!(res.join("dummy_triagebot.toml").exists()); // in rust-analyzer just "triagebot.toml".
     res
 }


### PR DESCRIPTION
This commit runs `cargo fmt` on the repository to apply rustfmt formatting to the repository. As we're preparing to publish the repository for public consumption using consistent automatic formatting for the source code makes contribution easier (and avoid needless arguments on style conventions and preferences).