### PR TITLE
Add basic CI configuration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,27 @@
+---
+name: Rust
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Rust Format
+      run: cargo fmt --all -- --check
+    - name: Build
+      run: cargo build --verbose
+    - name: Clippy
+      run: cargo clippy -- -D warnings
+    - name: Run tests
+      run: cargo test --verbose


### PR DESCRIPTION
This commit adds a basic initial CI configuration. This just adds a single job that tests a build, runs `cargo fmt` and `cargo clippy` to ensure consistent formatting and style, and then runs the unittests. This provides coverage of the repo basics and we can expand and tweak this over time as the library evolves.