### PR TITLE
Move comments after opening curly to a different line

### DIFF
--- a/crates/lexer/src/lib.rs
+++ b/crates/lexer/src/lib.rs
@@ -524,7 +524,8 @@ impl Cursor<'_> {
                 self.bump();
                 // n.b. example of `empty_exponent` : 3.4e; This is a syntax error
                 let mut empty_exponent = false;
-                if self.first().is_ascii_digit() { // preferred to is_digit(10), in rust lexer
+                // preferred to is_digit(10), in rust lexer
+                if self.first().is_ascii_digit() {
                     self.eat_decimal_digits();
                     match self.first() {
                         'e' | 'E' => {

--- a/crates/oq3_syntax/examples/demotest.rs
+++ b/crates/oq3_syntax/examples/demotest.rs
@@ -77,7 +77,8 @@ fn main() {
                 println!("{:?}", tok);
             }
         }
-        None => { // TODO shoul pring usage here.
+        None => {
+            // FIXME should print usage here.
             println!("Commands are parse, parse-green, and lex")
         }
     }

--- a/crates/oq3_syntax/src/ast/expr_ext.rs
+++ b/crates/oq3_syntax/src/ast/expr_ext.rs
@@ -236,9 +236,11 @@ impl ast::RangeExpr {
         let first = children.next();
         let second = children.next();
         let third = children.next();
-        if third.is_none() { // start:stop
+        if third.is_none() {
+             // start:stop
             (first, third, second)
-        } else { // start:step:stop
+        } else {
+            // start:step:stop
             (first, second, third)
         }
     }

--- a/crates/parser/src/grammar/expressions.rs
+++ b/crates/parser/src/grammar/expressions.rs
@@ -86,7 +86,7 @@ pub(crate) fn stmt(p: &mut Parser<'_>, semicolon: Semicolon) {
             return;
         };
     if let Some((cm, blocklike)) = expr_stmt(p, Some(m)) {
-        if !p.at(T!['}']) { //  && ( semicolon == Semicolon::Required || ! p.at(EOF)) {
+        if !p.at(T!['}']) {
             let cm_kind = cm.kind();
             let m = cm.precede(p);
             if blocklike.is_block() {
@@ -287,8 +287,9 @@ const LHS_FIRST: TokenSet =
 // Handles only prefix and postfix expressions?? Not binary infix?
 fn lhs(p: &mut Parser<'_>, r: Restrictions) -> Option<(CompletedMarker, BlockLike, bool)> {
     let m;
-    let kind = match p.current() { // Unary operators. In OQ3 should be ~ ! -
-        T![~] | T![!] | T![-] => {  // In r-a this is * ! -
+    // Unary operators. In OQ3 should be ~ ! -, In r-a this is * ! -
+    let kind = match p.current() {
+        T![~] | T![!] | T![-] => {
             m = p.start();
             p.bump_any();
             PREFIX_EXPR

--- a/crates/parser/src/grammar/items.rs
+++ b/crates/parser/src/grammar/items.rs
@@ -89,7 +89,8 @@ pub(super) fn opt_item(p: &mut Parser<'_>, m: Marker) -> Result<(), Marker> {
     //     return Ok(())
     // }
     // if p.current().is_classical_type() {
-    //     if la == T!['('] { // we should not be handling expressions here, only statements.
+    //     // we should not be handling expressions here, only statements.
+    //     if la == T!['('] {
     //         expressions::cast_expr(p, m);
     //     } else {
     //         expressions::classical_declaration_stmt(p, m);
@@ -131,7 +132,8 @@ fn gate_call_stmt(p: &mut Parser<'_>, m: Marker) {
 //    expressions::var_name(p);
     expressions::atom::identifier(p); // name of gate
     assert!(! p.at(T!['(']));
-    if p.at(T!['(']) { // This is never true, I hope
+    // This is never true, I hope
+    if p.at(T!['(']) {
         expressions::call_arg_list(p);
     }
     params::arg_list_gate_call_qubits(p);
@@ -147,7 +149,7 @@ fn gphase_call(p: &mut Parser<'_>, m: Marker) {
     m.complete(p, G_PHASE_CALL_STMT);
 }
 
-fn if_stmt(p: &mut Parser<'_>, m: Marker) { // -> CompletedMarker {
+fn if_stmt(p: &mut Parser<'_>, m: Marker) {
     assert!(p.at(T![if]));
 //    let m = p.start();
     p.bump(T![if]);
@@ -262,7 +264,7 @@ fn reset_(p: &mut Parser<'_>, m: Marker) {
 }
 
 // FIXME: this has underscore, so should be private.
-// We shoudld be able to refactor to keep this private.
+// We should be able to refactor to keep this private.
 pub(crate) fn measure_(p: &mut Parser<'_>, m: Marker) {
     p.bump(T![measure]);
     match p.current() {


### PR DESCRIPTION
A bug in `rustfmt`  https://github.com/rust-lang/rustfmt/issues/3255 moves comments on the same line as opening curly to an incorrect place. Probably should not move it at all.

This PR moves all such occurrences found with the regex `{\s+//` to a line that makes sense. Then `rustfmt` will likely not touch them.

* See #2