### PR TITLE
Add CI workflow to publish crates on tag/release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        crate: [lexer, parser, semantics, sourcegen, oq3_syntax, qasm3_bytecode, source_file]
+        crate: [oq3_lexer, oq3_parser, oq3_semantics, oq3_sourcegen, oq3_syntax, oq3_source_file]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        crate: [oq3_lexer, oq3_parser, oq3_semantics, oq3_sourcegen, oq3_syntax, oq3_source_file]
+        crate: [oq3_lexer, oq3_parser, oq3_semantics, oq3_syntax, oq3_source_file]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        crate: [oq3_lexer, oq3_parser, oq3_semantics, oq3_syntax, oq3_source_file]
+        crate: [oq3_lexer, oq3_parser, oq3_syntax, oq3_source_file, oq3_semantics]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,8 @@ on:
       - '*'
 
 jobs:
-  publish_lexer:
-    name: Publish oq3_lexer crate
+  publish_crates:
+    name: Publish openqasm3_parser crates
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+---
+name: Release openqasm3_parser
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  publish_lexer:
+    name: Publish oq3_lexer crate
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        crate: [lexer, parser, semantics, sourcegen, oq3_syntax, qasm3_bytecode, source_file]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Run cargo publish
+        run: |
+          cd crates/${{ matrix.crate }}
+          cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
This commit adds a new github actions work to publish the package's crates to crates.io. This new CI job run cargo publish on the respective crates in the correct order to publish the entire workspace.