### PR TITLE
Update rust to 1.72

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 version = "0.0.1"
-rust-version = "1.70"
+rust-version = "1.72"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["OpenQASM3 parser team"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,7 +3,7 @@
 
 # Copyright contributors to the openqasm-parser project
 
-channel = "1.70.0"
+channel = "1.72.0"
 components = [
   "cargo",
   "clippy",


### PR DESCRIPTION
I tried building this on my Macbook (aarch64-apple-darwin) and ran into some build issues

```
...
   Compiling utf8parse v0.2.1
   Compiling colorchoice v1.0.0
error[E0658]: use of unstable library feature 'stdsimd'
   --> /Users/edavis/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ahash-0.8.7/src/operations.rs:124:24
    |
124 |     let res = unsafe { vaesmcq_u8(vaeseq_u8(transmute!(value), transmute!(0u128))) };
    |                        ^^^^^^^^^^
    |
    = note: see issue #48556 <https://github.com/rust-lang/rust/issues/48556> for more information

error[E0658]: use of unstable library feature 'stdsimd'
   --> /Users/edavis/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ahash-0.8.7/src/operations.rs:124:35
    |
124 |     let res = unsafe { vaesmcq_u8(vaeseq_u8(transmute!(value), transmute!(0u128))) };
    |                                   ^^^^^^^^^
    |
    = note: see issue #48556 <https://github.com/rust-lang/rust/issues/48556> for more information

error[E0658]: use of unstable library feature 'stdsimd'
   --> /Users/edavis/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ahash-0.8.7/src/operations.rs:154:24
    |
154 |     let res = unsafe { vaesimcq_u8(vaesdq_u8(transmute!(value), transmute!(0u128))) };
    |                        ^^^^^^^^^^^
    |
    = note: see issue #48556 <https://github.com/rust-lang/rust/issues/48556> for more information

error[E0658]: use of unstable library feature 'stdsimd'
   --> /Users/edavis/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ahash-0.8.7/src/operations.rs:154:36
    |
154 |     let res = unsafe { vaesimcq_u8(vaesdq_u8(transmute!(value), transmute!(0u128))) };
    |                                    ^^^^^^^^^
    |
    = note: see issue #48556 <https://github.com/rust-lang/rust/issues/48556> for more information

For more information about this error, try `rustc --explain E0658`.
error: could not compile `ahash` (lib) due to 4 previous errors
warning: build failed, waiting for other jobs to finish...
```

It appears this unstable feature is stable as of 1.72 (cf. [this discussion](https://github.com/tkaitchuck/aHash/issues/195)). This PR just bumps to that.