### PR TITLE
Make debugging in release build a compiler error

### DIFF
--- a/crates/oq3_semantics/src/syntax_to_semantics.rs
+++ b/crates/oq3_semantics/src/syntax_to_semantics.rs
@@ -24,6 +24,10 @@ use oq3_syntax::ast as synast; // Syntactic AST
 
 use crate::with_scope;
 
+// dprintln, ddbg are defined in utils.rs
+#[allow(unused_imports)]
+#[cfg(debug_assertions)]
+use crate::{dprintln, ddbg};
 use crate::utils::type_name_of; // for debugging
 
 // traits

--- a/crates/oq3_semantics/src/syntax_to_semantics.rs
+++ b/crates/oq3_semantics/src/syntax_to_semantics.rs
@@ -25,10 +25,10 @@ use oq3_syntax::ast as synast; // Syntactic AST
 use crate::with_scope;
 
 // dprintln, ddbg are defined in utils.rs
+use crate::utils::type_name_of;
 #[allow(unused_imports)]
 #[cfg(debug_assertions)]
-use crate::{dprintln, ddbg};
-use crate::utils::type_name_of; // for debugging
+use crate::{ddbg, dprintln}; // for debugging
 
 // traits
 use synast::{HasArgList, HasModuleItem, HasName, HasTextName};

--- a/crates/oq3_semantics/src/utils.rs
+++ b/crates/oq3_semantics/src/utils.rs
@@ -31,3 +31,40 @@ macro_rules! dbg_stdout {
         ($(::std::dbg_stdout!($val)),+,)
     };
 }
+
+/// This is the same as `dbg!`, except that it is only defined in a debug build.
+/// Attempting use in a release build will result in an error
+/// `error: cannot determine resolution for the macro ddbg`
+#[cfg(debug_assertions)]
+#[macro_export]
+macro_rules! ddbg {
+    () => {
+        println!("[{}:{}:{}]", file!(), line!(), column!())
+    };
+    ($val:expr $(,)?) => {
+        match $val {
+            tmp => {
+                eprintln!("[{}:{}:{}] {} = {:#?}",
+                    file!(), line!(), column!(), stringify!($val), &tmp);
+                tmp
+            }
+        }
+    };
+    ($($val:expr),+ $(,)?) => {
+        ($(ddbg!($val)),+,)
+    };
+}
+
+/// This is the same as `println!`, except that it is only defined in a debug build.
+/// Attempting use in a release build will result in an error
+/// `error: cannot determine resolution for the macro dprintln!`
+#[cfg(debug_assertions)]
+#[macro_export]
+macro_rules! dprintln {
+    () => {
+        print!("\n")
+    };
+    ($($arg:tt)*) => {{
+        println!($($arg)*);
+    }};
+}


### PR DESCRIPTION
This commit adds macros `ddbg` and `dprintln`, which are defined in debug builds, but not in release builds. So, if they appear in code they will result in a compile time error when doing a release build. These are only added to the `oq3_semantics` crate. They would have to be duplicated to use them in other crates. Or perhaps moved to the lexer crate, which all others depend on, directly or indirectly.

Using these requires also `#[cfg(debug_assertions)]` when importing them.

I have seen an implementation of something similar that includes a definition of the macros for release builds. This does not then require #[cfg(debug_assertions)] on import. We could do something similar, by making `ddbg` expand to something that fails to compile, say references an undefined variable.  But that would not be very robust.

There is a probably a standalone, registered, crate to do things like this. But I was unable to find such a crate. Nor did I find online any reference to the basic problem this is meant to solve.