### PR TITLE
Configure clippy for `dbg_macro` and MSRV

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,6 @@ jobs:
     - name: Build
       run: cargo build --release --verbose
     - name: Clippy
-      run: cargo clippy --all-targets -- -D warnings
+      run: cargo clippy --all-targets -- -D warnings -D clippy::dbg_macro
     - name: Run tests
       run: cargo test --verbose -- --skip sourcegen_ast --skip sourcegen_ast_nodes

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,2 +1,4 @@
 # This does not work for some reason.
 # filter-map-identitiy = false
+
+msrv = "1.70.0"

--- a/crates/oq3_semantics/examples/semdemo.rs
+++ b/crates/oq3_semantics/examples/semdemo.rs
@@ -91,6 +91,7 @@ fn main() {
             result.program().print_asg_debug();
         }
 
+        #[allow(clippy::dbg_macro)]
         Some(Commands::Semantic { file_name }) => {
             let result = syntax_to_semantics::parse_source_file(file_name);
             let have_errors = result.any_errors();

--- a/local_CI.sh
+++ b/local_CI.sh
@@ -5,5 +5,5 @@
 
 cargo fmt --all -- --check || exit 1
 cargo build --release --verbose || exit 1
-cargo clippy --all-targets -- -D warnings || exit 1
+cargo clippy --all-targets -- -D warnings -D clippy::dbg_macro || exit 1
 cargo test --verbose -- --skip sourcegen_ast --skip sourcegen_ast_nodes || exit 1


### PR DESCRIPTION
This PR uses clippy to
* Check for language constructs newer than a specified MSRV. The MSRV is set to 1.70.0.
* Check for uses of `dbg!` macro. These should be present neither on the main branch nor in releases of crates in this repo.

* This PR partially replaces #43

#43 uses a custom macro to essential do what we do here. It is rather cumbersome and difficult to use across crates.
However #43 also defines `dprintln!` which is like `println!` but causes release builds to fail.

