### PR TITLE
Remove dependency on crate `source-span`

### DIFF
--- a/crates/oq3_source_file/Cargo.toml
+++ b/crates/oq3_source_file/Cargo.toml
@@ -17,4 +17,3 @@ doctest = false
 [dependencies]
 ariadne = { version = "0.3.0", features = ["auto-color"] }
 oq3_syntax.workspace = true
-source-span = { version = "2.7.0" }


### PR DESCRIPTION
This dependency was listed in crates/oq3_source_file/Cargo.toml But in fact it is not used. `source-span` depends on `termion`. The latter does not work on Windows, so we don't want it.

It may be possible to disable the `termion` feature if for some reason `source-span` turns out to be useful.