### PR TITLE
Run CI on macos and windows in addition to linux

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,8 +13,11 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
-
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-11, windows-latest]
     steps:
     - uses: actions/checkout@v3
     - name: Rust Format


### PR DESCRIPTION
Previously, CI only builds and tests on linux. With this PR, we also test macos and windows.