### PR TITLE
Set type of measurement expression correctly

### DIFF
--- a/crates/oq3_semantics/src/asg.rs
+++ b/crates/oq3_semantics/src/asg.rs
@@ -55,6 +55,7 @@ impl Program {
         let _ = &self.stmts.push(stmt);
     }
 
+    // FIXME: This should probably log a semantic error rather than panic.
     // The check should be done when checking syntax.
     // This check may be overly restrictive, as one might want to manipulate
     // or construct a `Program` in a way other than sequentially translating
@@ -582,10 +583,7 @@ impl MeasureExpression {
         let out_type = match self.operand.get_type() {
             Type::Qubit | Type::HardwareQubit => Type::Bit(IsConst::False),
             Type::QubitArray(dims) => Type::BitArray(dims.clone(), IsConst::False),
-            _ => panic!(
-                "Measure expression operand has type {:?}",
-                self.operand.get_type()
-            ),
+            _ => Type::Undefined,
         };
         TExpr::new(Expr::MeasureExpression(self), out_type)
     }

--- a/crates/oq3_semantics/src/asg.rs
+++ b/crates/oq3_semantics/src/asg.rs
@@ -578,10 +578,16 @@ impl MeasureExpression {
         &self.operand
     }
 
-    // FIXME: type may not be correct here.
-    // This assumes a single qubit is measured.
     pub fn to_texpr(self) -> TExpr {
-        TExpr::new(Expr::MeasureExpression(self), Type::Bit(IsConst::False))
+        let out_type = match self.operand.get_type() {
+            Type::Qubit | Type::HardwareQubit => Type::Bit(IsConst::False),
+            Type::QubitArray(dims) => Type::BitArray(dims.clone(), IsConst::False),
+            _ => panic!(
+                "Measure expression operand has type {:?}",
+                self.operand.get_type()
+            ),
+        };
+        TExpr::new(Expr::MeasureExpression(self), out_type)
     }
 }
 

--- a/crates/oq3_semantics/src/syntax_to_semantics.rs
+++ b/crates/oq3_semantics/src/syntax_to_semantics.rs
@@ -247,12 +247,18 @@ fn from_gate_operand(gate_operand: synast::GateOperand, context: &mut Context) -
         synast::GateOperand::HardwareQubit(ref hwq) => {
             asg::GateOperand::HardwareQubit(ast_hardware_qubit(hwq)).to_texpr(Type::HardwareQubit)
         }
-        synast::GateOperand::Identifier(identifier) => {
-            let (astidentifier, typ) = ast_identifier(&identifier, context);
+        synast::GateOperand::Identifier(ref identifier) => {
+            let (astidentifier, typ) = ast_identifier(identifier, context);
+            if !matches!(typ, Type::Qubit | Type::HardwareQubit) {
+                context.insert_error(IncompatibleTypesError, &gate_operand);
+            }
             asg::GateOperand::Identifier(astidentifier).to_texpr(typ)
         }
-        synast::GateOperand::IndexedIdentifier(indexed_identifier) => {
-            let (indexed_identifier, typ) = ast_indexed_identifier(&indexed_identifier, context);
+        synast::GateOperand::IndexedIdentifier(ref indexed_identifier) => {
+            let (indexed_identifier, typ) = ast_indexed_identifier(indexed_identifier, context);
+            if !matches!(typ, Type::QubitArray(_)) {
+                context.insert_error(IncompatibleTypesError, &gate_operand);
+            }
             asg::GateOperand::IndexedIdentifier(indexed_identifier).to_texpr(typ)
         }
     }

--- a/crates/oq3_semantics/tests/from_string_tests.rs
+++ b/crates/oq3_semantics/tests/from_string_tests.rs
@@ -152,7 +152,7 @@ fn test_gate_call() {
 mygate(x, y) q;
 "##;
     let (program, errors, _symbol_table) = parse_string(code);
-    assert_eq!(errors.len(), 4);
+    assert_eq!(errors.len(), 5);
     assert_eq!(program.len(), 1);
 }
 


### PR DESCRIPTION
This PR does two things

* Set the type of a `measurement` (In `TExpr` with variant `MeasurementExpression`) correctly.
That is measuring a qubit or hardware qubit results in a bit. Measuring a qubit register results in a bit register of the same length.
* Log semantic errors  `IncompatibleTypeError` if the argument to `measure` is of invalid type.

See https://github.com/Qiskit/openqasm3_parser/pull/42#discussion_r1455554624

A type error in a typed expression (`TExpr`) is represented by a variant such as `Type::Unknown`. An alternative would be to let the type be a `Result`. In any case, in this PR, to continue with the current implementation, we choose `Type::Unknown` if the operand to `measure` is not a valid quantum type.

Closes #51