### PR TITLE
Make calling undefined gate log a `UndefGateError`

### DIFF
--- a/crates/oq3_semantics/src/context.rs
+++ b/crates/oq3_semantics/src/context.rs
@@ -68,6 +68,18 @@ impl Context {
         symbol_record
     }
 
+    /// Lookup the gate symbol, returing a SymbolRecordResult. Possibly log a `UndefGateError`.
+    pub(crate) fn lookup_gate_symbol<T>(&mut self, name: &str, node: &T) -> SymbolRecordResult
+    where
+        T: AstNode,
+    {
+        let symbol_record = self.symbol_table.lookup(name);
+        if symbol_record.is_err() {
+            self.semantic_errors.insert(UndefGateError, node);
+        }
+        symbol_record
+    }
+
     /// Bind `name` to new Symbol, returning SymbolIdResult. Possibly log a `RedeclarationError`.
     pub(crate) fn new_binding<T>(&mut self, name: &str, typ: &Type, node: &T) -> SymbolIdResult
     where

--- a/crates/oq3_semantics/src/semantic_error.rs
+++ b/crates/oq3_semantics/src/semantic_error.rs
@@ -15,6 +15,7 @@ use crate::TextRange;
 #[derive(Clone, Debug)]
 pub enum SemanticErrorKind {
     UndefVarError,
+    UndefGateError,
     RedeclarationError,
     ConstIntegerError, // need a better way to organize this kind of type error
     IncompatibleTypesError,

--- a/crates/oq3_semantics/src/syntax_to_semantics.rs
+++ b/crates/oq3_semantics/src/syntax_to_semantics.rs
@@ -475,7 +475,7 @@ fn from_item(item: synast::Item, context: &mut Context) -> Option<asg::Stmt> {
             // FIXME: make sure we are efficient with strings
             let gate_name = gate_call.identifier().unwrap().text().to_string();
             let (symbol_result, _typ) = context
-                .lookup_symbol(gate_name.as_ref(), &gate_id.unwrap())
+                .lookup_gate_symbol(gate_name.as_ref(), &gate_id.unwrap())
                 .as_tuple();
             Some(asg::Stmt::GateCall(asg::GateCall::new(
                 symbol_result,


### PR DESCRIPTION
Previously, this logged a `UndefVarError`.