### PR TITLE
Implement `IndexedIdentifier` for `lvalue` of assignment

### DIFF
--- a/crates/oq3_semantics/src/asg.rs
+++ b/crates/oq3_semantics/src/asg.rs
@@ -359,8 +359,13 @@ impl ExpressionList {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum LValue {
     Identifier(SymbolIdResult),
-    ArraySlice(ArraySlice),
-    RegisterSlice(RegisterSlice),
+    // We want to remove IndexedIdentifier in favor of more precise types below.
+    IndexedIdentifier(IndexedIdentifier),
+    // FIXME: We really want the following which carry more semantic content.
+    // We have to check types to determine which of these we have. They
+    // also have (sometimes) differing syntax.
+    // ArraySlice(ArraySlice),
+    // RegisterSlice(RegisterSlice),
 }
 
 // For example `expr` in `v[expr]`, or `1:3` in `v[1:3]`

--- a/crates/oq3_semantics/tests/from_string_tests.rs
+++ b/crates/oq3_semantics/tests/from_string_tests.rs
@@ -257,3 +257,28 @@ barrier $0, $1;
     assert!(errors.is_empty());
     assert_eq!(program.len(), 3);
 }
+
+#[test]
+fn test_from_string_assign_indexed() {
+    let code = r#"
+qubit q;
+bit[2] c;
+c[0] = measure q;
+"#;
+    let (program, errors, _symbol_table) = parse_string(code);
+    assert!(errors.is_empty());
+    assert_eq!(program.len(), 3);
+}
+
+#[test]
+fn test_from_string_assign_indexed_2() {
+    let code = r#"
+OPENQASM 3.0;
+
+bit[2] out;
+out[0] = measure $0;
+"#;
+    let (program, errors, _symbol_table) = parse_string(code);
+    assert!(errors.is_empty());
+    assert_eq!(program.len(), 2);
+}

--- a/crates/oq3_syntax/src/ast/expr_ext.rs
+++ b/crates/oq3_syntax/src/ast/expr_ext.rs
@@ -421,6 +421,12 @@ impl ast::IndexedIdentifier {
     }
 }
 
+impl ast::AssignmentStmt {
+    pub fn indexed_identifier(&self) -> Option<ast::IndexedIdentifier> {
+        support::child(&self.syntax)
+    }
+}
+
 impl ast::GateCallStmt {
     // This may be redundant
     pub fn name(&self) -> Option<ast::Name> {


### PR DESCRIPTION
All of the failing examples given in #38 are included as (passing) tests. Either in this PR or in earlier PRs.

Part of the fix for #38 was done in #42, which implemented `measure`.
The other part of the fix for #38 is in the present PR, which allows indexed identifiers as lvalues in assignment.

Closes #38