### PR TITLE
Implement passing qasm source search paths in entry points

### DIFF
--- a/crates/oq3_semantics/examples/semdemo.rs
+++ b/crates/oq3_semantics/examples/semdemo.rs
@@ -82,7 +82,7 @@ fn main() {
         Some(Commands::SemanticString { file_name }) => {
             let source = read_example_source(file_name);
             let file_name = Some("giraffe");
-            let result = syntax_to_semantics::parse_source_string(source, file_name);
+            let result = syntax_to_semantics::parse_source_string(source, file_name, None);
             if result.any_errors() {
                 result.print_errors();
             }
@@ -91,7 +91,7 @@ fn main() {
 
         #[allow(clippy::dbg_macro)]
         Some(Commands::Semantic { file_name }) => {
-            let result = syntax_to_semantics::parse_source_file(file_name);
+            let result = syntax_to_semantics::parse_source_file(file_name, None);
             let have_errors = result.any_errors();
             if have_errors {
                 println!("Found errors: {}", have_errors);
@@ -106,7 +106,7 @@ fn main() {
         }
 
         Some(Commands::SemanticPretty { file_name }) => {
-            let result = syntax_to_semantics::parse_source_file(file_name);
+            let result = syntax_to_semantics::parse_source_file(file_name, None);
             println!("Found errors: {}", result.any_errors());
             result.print_errors();
             result.program().print_asg_debug_pretty();
@@ -118,7 +118,7 @@ fn main() {
         //     context.program().print_asg_debug_pretty();
         // }
         Some(Commands::Parse { file_name }) => {
-            let parsed_source = oq3_source_file::parse_source_file(file_name);
+            let parsed_source = oq3_source_file::parse_source_file(file_name, None);
             let parse_tree = parsed_source.syntax_ast().tree();
             println!(
                 "Found {} items",

--- a/crates/oq3_semantics/src/syntax_to_semantics.rs
+++ b/crates/oq3_semantics/src/syntax_to_semantics.rs
@@ -90,14 +90,19 @@ impl ParseResult<SourceString> {
 pub fn parse_source_string<T: ToString>(
     source: T,
     fake_file_path: Option<&str>,
+    search_path_list: Option<&Vec<PathBuf>>,
 ) -> ParseResult<SourceString> {
-    let parsed_source = oq3_source_file::parse_source_string(source, fake_file_path);
+    let parsed_source =
+        oq3_source_file::parse_source_string(source, fake_file_path, search_path_list);
     analyze_source(parsed_source)
 }
 
 /// Parse source file to semantic ASG
-pub fn parse_source_file(file_path: &PathBuf) -> ParseResult<SourceFile> {
-    let parsed_source = oq3_source_file::parse_source_file(file_path);
+pub fn parse_source_file(
+    file_path: &PathBuf,
+    search_path_list: Option<&Vec<PathBuf>>,
+) -> ParseResult<SourceFile> {
+    let parsed_source = oq3_source_file::parse_source_file(file_path, search_path_list);
     analyze_source(parsed_source)
 }
 

--- a/crates/oq3_semantics/tests/from_string_tests.rs
+++ b/crates/oq3_semantics/tests/from_string_tests.rs
@@ -8,7 +8,9 @@ use oq3_semantics::syntax_to_semantics::parse_source_string;
 use oq3_semantics::types::{ArrayDims, IsConst, Type};
 
 fn parse_string(code: &str) -> (asg::Program, SemanticErrorList, SymbolTable) {
-    parse_source_string(code, None).take_context().as_tuple()
+    parse_source_string(code, None, None)
+        .take_context()
+        .as_tuple()
 }
 
 #[test]

--- a/crates/oq3_source_file/src/api.rs
+++ b/crates/oq3_source_file/src/api.rs
@@ -18,17 +18,25 @@ use crate::source_file::{
 
 /// Read source from `file_path` and parse to the syntactic AST.
 /// Parse and store included files recursively.
-pub fn parse_source_file(file_path: &PathBuf) -> SourceFile {
-    let full_path = expand_path(file_path).normalize();
-    let (syntax_ast, included) = parse_source_and_includes(read_source_file(&full_path).as_str());
+pub fn parse_source_file(
+    file_path: &PathBuf,
+    search_path_list: Option<&Vec<PathBuf>>,
+) -> SourceFile {
+    let full_path = expand_path(file_path, search_path_list).normalize();
+    let (syntax_ast, included) =
+        parse_source_and_includes(read_source_file(&full_path).as_str(), search_path_list);
     SourceFile::new(full_path, syntax_ast, included)
 }
 
 /// Read source from `file_path` and parse to the syntactic AST.
 /// Parse and store included files recursively.
-pub fn parse_source_string<T: ToString>(source: T, fake_file_path: Option<&str>) -> SourceString {
+pub fn parse_source_string<T: ToString>(
+    source: T,
+    fake_file_path: Option<&str>,
+    search_path_list: Option<&Vec<PathBuf>>,
+) -> SourceString {
     let source = source.to_string();
-    let (syntax_ast, included) = parse_source_and_includes(source.as_str());
+    let (syntax_ast, included) = parse_source_and_includes(source.as_str(), search_path_list);
     let fake_file_path = PathBuf::from(fake_file_path.unwrap_or("no file"));
     SourceString::new(source, fake_file_path, syntax_ast, included)
 }


### PR DESCRIPTION
`parse_source_file` and `parse_source_string` now take an `Option<&Vec<PathBuf>>` representing search paths that override the environment variable `QASM_PATH`.

Closes #18