### PR TITLE
Add CI job to build and test with MSRV

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,6 @@ env:
 
 jobs:
   build:
-
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -26,5 +25,20 @@ jobs:
       run: cargo build --release --verbose
     - name: Clippy
       run: cargo clippy --all-targets -- -D warnings -D clippy::dbg_macro
+    - name: Run tests
+      run: cargo test --verbose -- --skip sourcegen_ast --skip sourcegen_ast_nodes
+
+  msrv:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-11, windows-latest]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@1.70
+    - name: Build
+      run: cargo build --release --verbose
     - name: Run tests
       run: cargo test --verbose -- --skip sourcegen_ast --skip sourcegen_ast_nodes


### PR DESCRIPTION
This commit adds CI jobs to build and test with the MSRV (currently 1.70). Running this in CI verifies that we don't accidently break building for users building on our documented MSRV.