### PR TITLE
Remove cruft, unused items in ungrammar

### DIFF
--- a/crates/oq3_parser/src/shortcuts.rs
+++ b/crates/oq3_parser/src/shortcuts.rs
@@ -201,9 +201,6 @@ impl Builder<'_, '_> {
         match text.split_once('.') {
             Some((left, right)) => {
                 assert!(!left.is_empty());
-                (self.sink)(StrStep::Enter {
-                    kind: SyntaxKind::NAME_REF,
-                });
                 (self.sink)(StrStep::Token {
                     kind: SyntaxKind::INT_NUMBER,
                     text: left,
@@ -222,9 +219,6 @@ impl Builder<'_, '_> {
                     assert!(right.is_empty(), "{left}.{right}");
                     self.state = State::Normal;
                 } else {
-                    (self.sink)(StrStep::Enter {
-                        kind: SyntaxKind::NAME_REF,
-                    });
                     (self.sink)(StrStep::Token {
                         kind: SyntaxKind::INT_NUMBER,
                         text: right,

--- a/crates/oq3_parser/src/syntax_kind/syntax_kind_enum.rs
+++ b/crates/oq3_parser/src/syntax_kind/syntax_kind_enum.rs
@@ -75,7 +75,6 @@ pub enum SyntaxKind {
     RESET_KW,
     MEASURE_KW,
     PRAGMA_KW,
-    END_KW,
     LET_KW,
     BOX_KW,
     EXTERN_KW,
@@ -90,6 +89,7 @@ pub enum SyntaxKind {
     CONTINUE_KW,
     RETURN_KW,
     BREAK_KW,
+    END_KW,
     INPUT_KW,
     OUTPUT_KW,
     READONLY_KW,
@@ -175,10 +175,8 @@ pub enum SyntaxKind {
     PATH_SEGMENT,
     LITERAL,
     NAME,
-    NAME_REF,
     EXPR_STMT,
     TYPE_SPEC,
-    TYPE_ARG,
     TYPE,
     NEW_TYPE,
     DECLARED_VAR,
@@ -241,7 +239,6 @@ impl SyntaxKind {
                 | RESET_KW
                 | MEASURE_KW
                 | PRAGMA_KW
-                | END_KW
                 | LET_KW
                 | BOX_KW
                 | EXTERN_KW
@@ -256,6 +253,7 @@ impl SyntaxKind {
                 | CONTINUE_KW
                 | RETURN_KW
                 | BREAK_KW
+                | END_KW
                 | INPUT_KW
                 | OUTPUT_KW
                 | READONLY_KW
@@ -368,7 +366,6 @@ impl SyntaxKind {
             "reset" => RESET_KW,
             "measure" => MEASURE_KW,
             "pragma" => PRAGMA_KW,
-            "end" => END_KW,
             "let" => LET_KW,
             "box" => BOX_KW,
             "extern" => EXTERN_KW,
@@ -383,6 +380,7 @@ impl SyntaxKind {
             "continue" => CONTINUE_KW,
             "return" => RETURN_KW,
             "break" => BREAK_KW,
+            "end" => END_KW,
             "input" => INPUT_KW,
             "output" => OUTPUT_KW,
             "readonly" => READONLY_KW,
@@ -449,5 +447,5 @@ impl SyntaxKind {
     }
 }
 #[macro_export]
-macro_rules ! T { [++] => { $ crate :: SyntaxKind :: DOUBLE_PLUS } ; [;] => { $ crate :: SyntaxKind :: SEMICOLON } ; [,] => { $ crate :: SyntaxKind :: COMMA } ; ['('] => { $ crate :: SyntaxKind :: L_PAREN } ; [')'] => { $ crate :: SyntaxKind :: R_PAREN } ; ['{'] => { $ crate :: SyntaxKind :: L_CURLY } ; ['}'] => { $ crate :: SyntaxKind :: R_CURLY } ; ['['] => { $ crate :: SyntaxKind :: L_BRACK } ; [']'] => { $ crate :: SyntaxKind :: R_BRACK } ; [<] => { $ crate :: SyntaxKind :: L_ANGLE } ; [>] => { $ crate :: SyntaxKind :: R_ANGLE } ; [@] => { $ crate :: SyntaxKind :: AT } ; [#] => { $ crate :: SyntaxKind :: POUND } ; [~] => { $ crate :: SyntaxKind :: TILDE } ; [?] => { $ crate :: SyntaxKind :: QUESTION } ; [$] => { $ crate :: SyntaxKind :: DOLLAR } ; [&] => { $ crate :: SyntaxKind :: AMP } ; [|] => { $ crate :: SyntaxKind :: PIPE } ; [+] => { $ crate :: SyntaxKind :: PLUS } ; [*] => { $ crate :: SyntaxKind :: STAR } ; [/] => { $ crate :: SyntaxKind :: SLASH } ; [^] => { $ crate :: SyntaxKind :: CARET } ; [%] => { $ crate :: SyntaxKind :: PERCENT } ; [_] => { $ crate :: SyntaxKind :: UNDERSCORE } ; [.] => { $ crate :: SyntaxKind :: DOT } ; [..] => { $ crate :: SyntaxKind :: DOT2 } ; [...] => { $ crate :: SyntaxKind :: DOT3 } ; [..=] => { $ crate :: SyntaxKind :: DOT2EQ } ; [:] => { $ crate :: SyntaxKind :: COLON } ; [::] => { $ crate :: SyntaxKind :: COLON2 } ; [=] => { $ crate :: SyntaxKind :: EQ } ; [==] => { $ crate :: SyntaxKind :: EQ2 } ; [=>] => { $ crate :: SyntaxKind :: FAT_ARROW } ; [!] => { $ crate :: SyntaxKind :: BANG } ; [!=] => { $ crate :: SyntaxKind :: NEQ } ; [-] => { $ crate :: SyntaxKind :: MINUS } ; [->] => { $ crate :: SyntaxKind :: THIN_ARROW } ; [<=] => { $ crate :: SyntaxKind :: LTEQ } ; [>=] => { $ crate :: SyntaxKind :: GTEQ } ; [+=] => { $ crate :: SyntaxKind :: PLUSEQ } ; [-=] => { $ crate :: SyntaxKind :: MINUSEQ } ; [|=] => { $ crate :: SyntaxKind :: PIPEEQ } ; [&=] => { $ crate :: SyntaxKind :: AMPEQ } ; [^=] => { $ crate :: SyntaxKind :: CARETEQ } ; [/=] => { $ crate :: SyntaxKind :: SLASHEQ } ; [*=] => { $ crate :: SyntaxKind :: STAREQ } ; [%=] => { $ crate :: SyntaxKind :: PERCENTEQ } ; [&&] => { $ crate :: SyntaxKind :: AMP2 } ; [||] => { $ crate :: SyntaxKind :: PIPE2 } ; [<<] => { $ crate :: SyntaxKind :: SHL } ; [>>] => { $ crate :: SyntaxKind :: SHR } ; [<<=] => { $ crate :: SyntaxKind :: SHLEQ } ; [>>=] => { $ crate :: SyntaxKind :: SHREQ } ; [OPENQASM] => { $ crate :: SyntaxKind :: O_P_E_N_Q_A_S_M_KW } ; [include] => { $ crate :: SyntaxKind :: INCLUDE_KW } ; [def] => { $ crate :: SyntaxKind :: DEF_KW } ; [defcalgrammar] => { $ crate :: SyntaxKind :: DEFCALGRAMMAR_KW } ; [cal] => { $ crate :: SyntaxKind :: CAL_KW } ; [defcal] => { $ crate :: SyntaxKind :: DEFCAL_KW } ; [gate] => { $ crate :: SyntaxKind :: GATE_KW } ; [delay] => { $ crate :: SyntaxKind :: DELAY_KW } ; [reset] => { $ crate :: SyntaxKind :: RESET_KW } ; [measure] => { $ crate :: SyntaxKind :: MEASURE_KW } ; [pragma] => { $ crate :: SyntaxKind :: PRAGMA_KW } ; [end] => { $ crate :: SyntaxKind :: END_KW } ; [let] => { $ crate :: SyntaxKind :: LET_KW } ; [box] => { $ crate :: SyntaxKind :: BOX_KW } ; [extern] => { $ crate :: SyntaxKind :: EXTERN_KW } ; [const] => { $ crate :: SyntaxKind :: CONST_KW } ; [barrier] => { $ crate :: SyntaxKind :: BARRIER_KW } ; [gphase] => { $ crate :: SyntaxKind :: GPHASE_KW } ; [if] => { $ crate :: SyntaxKind :: IF_KW } ; [else] => { $ crate :: SyntaxKind :: ELSE_KW } ; [for] => { $ crate :: SyntaxKind :: FOR_KW } ; [in] => { $ crate :: SyntaxKind :: IN_KW } ; [while] => { $ crate :: SyntaxKind :: WHILE_KW } ; [continue] => { $ crate :: SyntaxKind :: CONTINUE_KW } ; [return] => { $ crate :: SyntaxKind :: RETURN_KW } ; [break] => { $ crate :: SyntaxKind :: BREAK_KW } ; [input] => { $ crate :: SyntaxKind :: INPUT_KW } ; [output] => { $ crate :: SyntaxKind :: OUTPUT_KW } ; [readonly] => { $ crate :: SyntaxKind :: READONLY_KW } ; [mutable] => { $ crate :: SyntaxKind :: MUTABLE_KW } ; [qreg] => { $ crate :: SyntaxKind :: QREG_KW } ; [creg] => { $ crate :: SyntaxKind :: CREG_KW } ; [qubit] => { $ crate :: SyntaxKind :: QUBIT_KW } ; [void] => { $ crate :: SyntaxKind :: VOID_KW } ; [array] => { $ crate :: SyntaxKind :: ARRAY_KW } ; [false] => { $ crate :: SyntaxKind :: FALSE_KW } ; [true] => { $ crate :: SyntaxKind :: TRUE_KW } ; [float] => { $ crate :: SyntaxKind :: FLOAT_TY } ; [int] => { $ crate :: SyntaxKind :: INT_TY } ; [uint] => { $ crate :: SyntaxKind :: UINT_TY } ; [complex] => { $ crate :: SyntaxKind :: COMPLEX_TY } ; [bool] => { $ crate :: SyntaxKind :: BOOL_TY } ; [bit] => { $ crate :: SyntaxKind :: BIT_TY } ; [duration] => { $ crate :: SyntaxKind :: DURATION_TY } ; [stretch] => { $ crate :: SyntaxKind :: STRETCH_TY } ; [angle] => { $ crate :: SyntaxKind :: ANGLE_TY } ; [ident] => { $ crate :: SyntaxKind :: IDENT } ; }
+macro_rules ! T { [++] => { $ crate :: SyntaxKind :: DOUBLE_PLUS } ; [;] => { $ crate :: SyntaxKind :: SEMICOLON } ; [,] => { $ crate :: SyntaxKind :: COMMA } ; ['('] => { $ crate :: SyntaxKind :: L_PAREN } ; [')'] => { $ crate :: SyntaxKind :: R_PAREN } ; ['{'] => { $ crate :: SyntaxKind :: L_CURLY } ; ['}'] => { $ crate :: SyntaxKind :: R_CURLY } ; ['['] => { $ crate :: SyntaxKind :: L_BRACK } ; [']'] => { $ crate :: SyntaxKind :: R_BRACK } ; [<] => { $ crate :: SyntaxKind :: L_ANGLE } ; [>] => { $ crate :: SyntaxKind :: R_ANGLE } ; [@] => { $ crate :: SyntaxKind :: AT } ; [#] => { $ crate :: SyntaxKind :: POUND } ; [~] => { $ crate :: SyntaxKind :: TILDE } ; [?] => { $ crate :: SyntaxKind :: QUESTION } ; [$] => { $ crate :: SyntaxKind :: DOLLAR } ; [&] => { $ crate :: SyntaxKind :: AMP } ; [|] => { $ crate :: SyntaxKind :: PIPE } ; [+] => { $ crate :: SyntaxKind :: PLUS } ; [*] => { $ crate :: SyntaxKind :: STAR } ; [/] => { $ crate :: SyntaxKind :: SLASH } ; [^] => { $ crate :: SyntaxKind :: CARET } ; [%] => { $ crate :: SyntaxKind :: PERCENT } ; [_] => { $ crate :: SyntaxKind :: UNDERSCORE } ; [.] => { $ crate :: SyntaxKind :: DOT } ; [..] => { $ crate :: SyntaxKind :: DOT2 } ; [...] => { $ crate :: SyntaxKind :: DOT3 } ; [..=] => { $ crate :: SyntaxKind :: DOT2EQ } ; [:] => { $ crate :: SyntaxKind :: COLON } ; [::] => { $ crate :: SyntaxKind :: COLON2 } ; [=] => { $ crate :: SyntaxKind :: EQ } ; [==] => { $ crate :: SyntaxKind :: EQ2 } ; [=>] => { $ crate :: SyntaxKind :: FAT_ARROW } ; [!] => { $ crate :: SyntaxKind :: BANG } ; [!=] => { $ crate :: SyntaxKind :: NEQ } ; [-] => { $ crate :: SyntaxKind :: MINUS } ; [->] => { $ crate :: SyntaxKind :: THIN_ARROW } ; [<=] => { $ crate :: SyntaxKind :: LTEQ } ; [>=] => { $ crate :: SyntaxKind :: GTEQ } ; [+=] => { $ crate :: SyntaxKind :: PLUSEQ } ; [-=] => { $ crate :: SyntaxKind :: MINUSEQ } ; [|=] => { $ crate :: SyntaxKind :: PIPEEQ } ; [&=] => { $ crate :: SyntaxKind :: AMPEQ } ; [^=] => { $ crate :: SyntaxKind :: CARETEQ } ; [/=] => { $ crate :: SyntaxKind :: SLASHEQ } ; [*=] => { $ crate :: SyntaxKind :: STAREQ } ; [%=] => { $ crate :: SyntaxKind :: PERCENTEQ } ; [&&] => { $ crate :: SyntaxKind :: AMP2 } ; [||] => { $ crate :: SyntaxKind :: PIPE2 } ; [<<] => { $ crate :: SyntaxKind :: SHL } ; [>>] => { $ crate :: SyntaxKind :: SHR } ; [<<=] => { $ crate :: SyntaxKind :: SHLEQ } ; [>>=] => { $ crate :: SyntaxKind :: SHREQ } ; [OPENQASM] => { $ crate :: SyntaxKind :: O_P_E_N_Q_A_S_M_KW } ; [include] => { $ crate :: SyntaxKind :: INCLUDE_KW } ; [def] => { $ crate :: SyntaxKind :: DEF_KW } ; [defcalgrammar] => { $ crate :: SyntaxKind :: DEFCALGRAMMAR_KW } ; [cal] => { $ crate :: SyntaxKind :: CAL_KW } ; [defcal] => { $ crate :: SyntaxKind :: DEFCAL_KW } ; [gate] => { $ crate :: SyntaxKind :: GATE_KW } ; [delay] => { $ crate :: SyntaxKind :: DELAY_KW } ; [reset] => { $ crate :: SyntaxKind :: RESET_KW } ; [measure] => { $ crate :: SyntaxKind :: MEASURE_KW } ; [pragma] => { $ crate :: SyntaxKind :: PRAGMA_KW } ; [let] => { $ crate :: SyntaxKind :: LET_KW } ; [box] => { $ crate :: SyntaxKind :: BOX_KW } ; [extern] => { $ crate :: SyntaxKind :: EXTERN_KW } ; [const] => { $ crate :: SyntaxKind :: CONST_KW } ; [barrier] => { $ crate :: SyntaxKind :: BARRIER_KW } ; [gphase] => { $ crate :: SyntaxKind :: GPHASE_KW } ; [if] => { $ crate :: SyntaxKind :: IF_KW } ; [else] => { $ crate :: SyntaxKind :: ELSE_KW } ; [for] => { $ crate :: SyntaxKind :: FOR_KW } ; [in] => { $ crate :: SyntaxKind :: IN_KW } ; [while] => { $ crate :: SyntaxKind :: WHILE_KW } ; [continue] => { $ crate :: SyntaxKind :: CONTINUE_KW } ; [return] => { $ crate :: SyntaxKind :: RETURN_KW } ; [break] => { $ crate :: SyntaxKind :: BREAK_KW } ; [end] => { $ crate :: SyntaxKind :: END_KW } ; [input] => { $ crate :: SyntaxKind :: INPUT_KW } ; [output] => { $ crate :: SyntaxKind :: OUTPUT_KW } ; [readonly] => { $ crate :: SyntaxKind :: READONLY_KW } ; [mutable] => { $ crate :: SyntaxKind :: MUTABLE_KW } ; [qreg] => { $ crate :: SyntaxKind :: QREG_KW } ; [creg] => { $ crate :: SyntaxKind :: CREG_KW } ; [qubit] => { $ crate :: SyntaxKind :: QUBIT_KW } ; [void] => { $ crate :: SyntaxKind :: VOID_KW } ; [array] => { $ crate :: SyntaxKind :: ARRAY_KW } ; [false] => { $ crate :: SyntaxKind :: FALSE_KW } ; [true] => { $ crate :: SyntaxKind :: TRUE_KW } ; [float] => { $ crate :: SyntaxKind :: FLOAT_TY } ; [int] => { $ crate :: SyntaxKind :: INT_TY } ; [uint] => { $ crate :: SyntaxKind :: UINT_TY } ; [complex] => { $ crate :: SyntaxKind :: COMPLEX_TY } ; [bool] => { $ crate :: SyntaxKind :: BOOL_TY } ; [bit] => { $ crate :: SyntaxKind :: BIT_TY } ; [duration] => { $ crate :: SyntaxKind :: DURATION_TY } ; [stretch] => { $ crate :: SyntaxKind :: STRETCH_TY } ; [angle] => { $ crate :: SyntaxKind :: ANGLE_TY } ; [ident] => { $ crate :: SyntaxKind :: IDENT } ; }
 pub use T;

--- a/crates/oq3_syntax/openqasm3.ungram
+++ b/crates/oq3_syntax/openqasm3.ungram
@@ -53,15 +53,6 @@
 Name =
   'ident'
 
-NameRef =
-  'ident' | 'int_number'
-
-TypeArg =
-  Type
-
-// ConstArg =
-//   Expr
-
 //*************************//
 //          Items          //
 //*************************//
@@ -108,7 +99,7 @@ ContinueStmt =
   'continue' ';'
 
 EndStmt =
-  'break' ';'
+  'end' ';'
 
 VersionString =
   'OPENQASM' version:Version ';'
@@ -143,9 +134,6 @@ Include =
 // code for extracting string from FilePath is in expr_ext.rs
 FilePath =
  'string'
-
-// ItemList =
-//   '{' Item* '}'
 
 TypeDeclarationStmt =
    TypeSpec Name ('=' Expr)? ';'
@@ -249,7 +237,6 @@ LetStmt =
 ConcatenationExpr =
    Expr '++' Expr concat:('++' Expr)*
 
-
 BlockExpr =
   '{'
     statements:Stmt*
@@ -336,18 +323,6 @@ BoxExpr =
 //          Types          //
 //*************************//
 
-// ScalarTypeName =
-//     value:('bit'
-//     | 'int'
-//     | 'uint'
-//     | 'float'
-//     | 'angle'
-//     | 'bool'
-//     | 'duration'
-//     | 'stretch'
-//     | 'complex'
-//     )
-
 // FIXME: move optional `const` here. This is currently
 // in ClassicalDeclarationStatement.
 ScalarType =
@@ -360,7 +335,6 @@ ScalarType =
     | 'duration'
     | 'stretch'
     | 'complex' ('[' ScalarType ']')?
-
 
 Designator =
   '[' Expr ']'
@@ -390,18 +364,12 @@ AliasDeclarationStatement =
 AliasExpression =
    Expr concat:('++' Expr)*
 
-// DeclarationExpression =
-//     ArrayLiteral | Expr | MeasureExpression
-
 MeasureExpression =
     'measure' GateOperand
 
 // We keep Identifier and IndexedIdentifier separate
 GateOperand =
   Identifier | IndexedIdentifier | HardwareQubit
-
-IntNum =
-  'int_number'
 
 SetExpression =
     '{' ExpressionList '}'
@@ -418,25 +386,12 @@ IndexKind =
 IndexedIdentifier =
     Name IndexOperator*
 
-// indexOperator:
-//     LBRACKET
-//     (
-//         setExpression
-//         | (expression | rangeExpression) (COMMA (expression | rangeExpression))* COMMA?
-//     )
-//     RBRACKET;
-
 ArrayLiteral =
   '{' ExpressionList '}'
 
 // // FIXME
 HardwareQubit =
   Name
-
-// Unable to get this work easily. Get obscure error during lowering. We will use just Expr
-// and deal with semantics later.
-// DeclarationExpression =
-//     Expr | MeasureExpression
 
 ClassicalDeclarationStatement =
  'const'? (ScalarType | ArrayType) Name ('=' Expr)? ';'
@@ -457,6 +412,3 @@ QuantumDeclarationStatement =
 
 AssignmentStmt =
     (Name | IndexedIdentifier) '=' rhs:Expr ';'
-
-Type =
-  ArrayType

--- a/crates/oq3_syntax/src/ast/generated/nodes.rs
+++ b/crates/oq3_syntax/src/ast/generated/nodes.rs
@@ -16,33 +16,6 @@ impl Name {
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct NameRef {
-    pub(crate) syntax: SyntaxNode,
-}
-impl NameRef {
-    pub fn ident_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, T![ident])
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct TypeArg {
-    pub(crate) syntax: SyntaxNode,
-}
-impl TypeArg {
-    pub fn ty(&self) -> Option<Type> {
-        support::child(&self.syntax)
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct Type {
-    pub(crate) syntax: SyntaxNode,
-}
-impl Type {
-    pub fn array_type(&self) -> Option<ArrayType> {
-        support::child(&self.syntax)
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SourceFile {
     pub(crate) syntax: SyntaxNode,
 }
@@ -402,8 +375,8 @@ pub struct EndStmt {
     pub(crate) syntax: SyntaxNode,
 }
 impl EndStmt {
-    pub fn break_token(&self) -> Option<SyntaxToken> {
-        support::token(&self.syntax, T![break])
+    pub fn end_token(&self) -> Option<SyntaxToken> {
+        support::token(&self.syntax, T![end])
     }
     pub fn semicolon_token(&self) -> Option<SyntaxToken> {
         support::token(&self.syntax, T![;])
@@ -881,11 +854,6 @@ impl AliasExpression {
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct IntNum {
-    pub(crate) syntax: SyntaxNode,
-}
-impl IntNum {}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SetExpression {
     pub(crate) syntax: SyntaxNode,
 }
@@ -1042,51 +1010,6 @@ impl ast::HasName for AnyHasName {}
 impl AstNode for Name {
     fn can_cast(kind: SyntaxKind) -> bool {
         kind == NAME
-    }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
-        if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
-        } else {
-            None
-        }
-    }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
-}
-impl AstNode for NameRef {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == NAME_REF
-    }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
-        if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
-        } else {
-            None
-        }
-    }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
-}
-impl AstNode for TypeArg {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == TYPE_ARG
-    }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
-        if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
-        } else {
-            None
-        }
-    }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
-}
-impl AstNode for Type {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == TYPE
     }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -1999,21 +1922,6 @@ impl AstNode for AliasExpression {
         &self.syntax
     }
 }
-impl AstNode for IntNum {
-    fn can_cast(kind: SyntaxKind) -> bool {
-        kind == INT_NUM
-    }
-    fn cast(syntax: SyntaxNode) -> Option<Self> {
-        if Self::can_cast(syntax.kind()) {
-            Some(Self { syntax })
-        } else {
-            None
-        }
-    }
-    fn syntax(&self) -> &SyntaxNode {
-        &self.syntax
-    }
-}
 impl AstNode for SetExpression {
     fn can_cast(kind: SyntaxKind) -> bool {
         kind == SET_EXPRESSION
@@ -2604,21 +2512,6 @@ impl std::fmt::Display for Name {
         std::fmt::Display::fmt(self.syntax(), f)
     }
 }
-impl std::fmt::Display for NameRef {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Display::fmt(self.syntax(), f)
-    }
-}
-impl std::fmt::Display for TypeArg {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Display::fmt(self.syntax(), f)
-    }
-}
-impl std::fmt::Display for Type {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Display::fmt(self.syntax(), f)
-    }
-}
 impl std::fmt::Display for SourceFile {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(self.syntax(), f)
@@ -2915,11 +2808,6 @@ impl std::fmt::Display for AliasDeclarationStatement {
     }
 }
 impl std::fmt::Display for AliasExpression {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Display::fmt(self.syntax(), f)
-    }
-}
-impl std::fmt::Display for IntNum {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(self.syntax(), f)
     }

--- a/crates/oq3_syntax/src/ast/make.rs
+++ b/crates/oq3_syntax/src/ast/make.rs
@@ -53,10 +53,6 @@ pub fn expr_stmt(expr: ast::Expr) -> ast::ExprStmt {
     ast_from_text(&format!("fn f() {{ {expr}{semi} (); }}"))
 }
 
-pub fn type_arg(ty: ast::Type) -> ast::TypeArg {
-    ast_from_text(&format!("const S: T<{ty}> = ();"))
-}
-
 #[track_caller]
 fn ast_from_text<N: AstNode>(text: &str) -> N {
     let parse = SourceFile::parse(text);

--- a/crates/oq3_syntax/src/tests/ast_src.rs
+++ b/crates/oq3_syntax/src/tests/ast_src.rs
@@ -80,7 +80,6 @@ pub(crate) const KINDS_SRC: KindsSrc<'_> = KindsSrc {
         "reset",
         "measure",
         "pragma",
-        "end",
         "let",
         "box",
         "extern",
@@ -96,6 +95,7 @@ pub(crate) const KINDS_SRC: KindsSrc<'_> = KindsSrc {
         "continue",
         "return",
         "break",
+        "end",
         // Types
         "input",
         "output",
@@ -180,12 +180,10 @@ pub(crate) const KINDS_SRC: KindsSrc<'_> = KindsSrc {
         "PATH_SEGMENT",
         "LITERAL",
         "NAME",
-        "NAME_REF",
         // "LET_ELSE",
         "EXPR_STMT",
         //        "TYPE_PARAM",
         "TYPE_SPEC", // "SPEC" to avoid the word "type"
-        "TYPE_ARG",
         "TYPE",
         "NEW_TYPE",
         "DECLARED_VAR",


### PR DESCRIPTION
This PR tidies up `openqasm3.ungram` a bit. Removes unused things. Fixes a thinko or two.

* remove commented out code
* remove unused pieces of ungrammar
* fix bug from copying error