### PR TITLE
Implement built-in constants

### DIFF
--- a/crates/oq3_semantics/src/symbols.rs
+++ b/crates/oq3_semantics/src/symbols.rs
@@ -3,6 +3,7 @@
 
 // Defines data structures and api for symbols, scope, and symbol tables.
 
+use crate::types;
 use crate::types::Type;
 use hashbrown::HashMap;
 
@@ -237,7 +238,11 @@ impl SymbolTable {
             symbol_table_stack: Vec::<SymbolMap>::new(),
             all_symbols: Vec::<Symbol>::new(),
         };
-        symbol_table.enter_scope(ScopeType::Global); // May want to initialize with some global symbols as well
+        symbol_table.enter_scope(ScopeType::Global);
+        for const_name in ["pi", "π", "euler", "ℇ", "tau", "τ"] {
+            let _ =
+                symbol_table.new_binding(const_name, &Type::Float(Some(64), types::IsConst::True));
+        }
         symbol_table
     }
 

--- a/crates/oq3_semantics/tests/ast_tests.rs
+++ b/crates/oq3_semantics/tests/ast_tests.rs
@@ -5,6 +5,8 @@ use oq3_semantics::asg;
 use oq3_semantics::symbols;
 use oq3_semantics::types;
 
+const NUM_BUILTIN_CONSTS: usize = 6;
+
 //
 // TExpr
 //
@@ -88,7 +90,7 @@ fn test_declaration() {
     let mut table = SymbolTable::new();
     let x = table.new_binding("x", &Type::Bool(IsConst::False));
     assert!(x.is_ok());
-    assert_eq!(table.len_current_scope(), 1);
+    assert_eq!(table.len_current_scope(), 1 + NUM_BUILTIN_CONSTS);
     let result = table.lookup("x");
     assert!(result.is_ok());
     assert_eq!(result.unwrap().symbol_id(), x.unwrap());

--- a/crates/oq3_semantics/tests/symbol_tests.rs
+++ b/crates/oq3_semantics/tests/symbol_tests.rs
@@ -4,6 +4,8 @@
 use oq3_semantics::symbols;
 use oq3_semantics::types;
 
+const NUM_BUILTIN_CONSTS: usize = 6;
+
 //
 // Test API of symbols and symbol tables
 //
@@ -13,7 +15,7 @@ fn test_symbol_table_create() {
     use symbols::SymbolTable;
 
     let table = SymbolTable::new();
-    assert_eq!(table.len_current_scope(), 0);
+    assert_eq!(table.len_current_scope(), NUM_BUILTIN_CONSTS);
     let result = table.lookup("x");
     assert!(result.is_err());
 }
@@ -27,7 +29,7 @@ fn test_symbol_table_bind() {
     let symbol_name = "x";
     let x = table.new_binding(symbol_name, &Type::Bool(IsConst::False));
     assert!(x.is_ok());
-    assert_eq!(table.len_current_scope(), 1);
+    assert_eq!(table.len_current_scope(), 1 + NUM_BUILTIN_CONSTS);
     let result = table.lookup(symbol_name);
     assert!(result.is_ok());
     assert_eq!(result.unwrap().symbol_id(), x.unwrap());


### PR DESCRIPTION
Implement global, built-in constants "pi", "π", "euler", "ℇ", "tau", "τ".

Closes #56