### PR TITLE
Add parameters for num classical params and num qubits to `Type::Gate`

### DIFF
--- a/crates/oq3_semantics/src/semantic_error.rs
+++ b/crates/oq3_semantics/src/semantic_error.rs
@@ -21,6 +21,8 @@ pub enum SemanticErrorKind {
     IncompatibleTypesError,
     MutateConstError,
     IncludeNotInGlobalScopeError,
+    NumGateParamsError,
+    NumGateQubitsError,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/oq3_semantics/src/symbols.rs
+++ b/crates/oq3_semantics/src/symbols.rs
@@ -239,10 +239,12 @@ impl SymbolTable {
             all_symbols: Vec::<Symbol>::new(),
         };
         symbol_table.enter_scope(ScopeType::Global);
+        // Define global, built-in constants
         for const_name in ["pi", "π", "euler", "ℇ", "tau", "τ"] {
             let _ =
                 symbol_table.new_binding(const_name, &Type::Float(Some(64), types::IsConst::True));
         }
+        let _ = symbol_table.new_binding("U", &Type::Gate(3, 1)); // U(a, b, c) q
         symbol_table
     }
 

--- a/crates/oq3_semantics/src/types.rs
+++ b/crates/oq3_semantics/src/types.rs
@@ -71,8 +71,8 @@ pub enum Type {
     DurationArray(ArrayDims),
 
     // Other
-    Gate,  // <-- this type seems anomalous
-    Range, // temporary placeholder, perhaps
+    Gate(i32, i32), // (num classical args, num quantum args)
+    Range,          // temporary placeholder, perhaps
     Void,
     ToDo, // not yet implemented
     // Undefined means a type that is erroneously non-existent. This is not the same as unknown.

--- a/crates/oq3_semantics/tests/ast_tests.rs
+++ b/crates/oq3_semantics/tests/ast_tests.rs
@@ -5,7 +5,7 @@ use oq3_semantics::asg;
 use oq3_semantics::symbols;
 use oq3_semantics::types;
 
-const NUM_BUILTIN_CONSTS: usize = 6;
+const NUM_BUILTIN_CONSTS: usize = 7;
 
 //
 // TExpr

--- a/crates/oq3_semantics/tests/symbol_tests.rs
+++ b/crates/oq3_semantics/tests/symbol_tests.rs
@@ -4,7 +4,7 @@
 use oq3_semantics::symbols;
 use oq3_semantics::types;
 
-const NUM_BUILTIN_CONSTS: usize = 6;
+const NUM_BUILTIN_CONSTS: usize = 7;
 
 //
 // Test API of symbols and symbol tables


### PR DESCRIPTION
* Use this modification of `Type::Gate` to compare the implied signature from a gate call and log errors if it does not match definition

* Log type mismatch error if gate call syntax is used, but the apparent gate is of a different type.

* Declare builtin gate `U`


Closes #24