### PR TITLE
Support `barrier;`, that is barrier with no qubit args

### DIFF
--- a/crates/oq3_semantics/src/asg.rs
+++ b/crates/oq3_semantics/src/asg.rs
@@ -594,17 +594,18 @@ impl MeasureExpression {
     }
 }
 
+// qubits == None represents `barrier;`
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Barrier {
-    qubits: Vec<TExpr>,
+    qubits: Option<Vec<TExpr>>,
 }
 
 impl Barrier {
-    pub fn new(qubits: Vec<TExpr>) -> Barrier {
+    pub fn new(qubits: Option<Vec<TExpr>>) -> Barrier {
         Barrier { qubits }
     }
 
-    pub fn qubits(&self) -> &Vec<TExpr> {
+    pub fn qubits(&self) -> &Option<Vec<TExpr>> {
         &self.qubits
     }
 }

--- a/crates/oq3_semantics/src/syntax_to_semantics.rs
+++ b/crates/oq3_semantics/src/syntax_to_semantics.rs
@@ -532,12 +532,12 @@ fn from_item(item: synast::Item, context: &mut Context) -> Option<asg::Stmt> {
         }
 
         synast::Item::Barrier(barrier) => {
-            let gate_operands: Vec<_> = barrier
-                .qubit_list()
-                .unwrap()
-                .gate_operands()
-                .map(|qubit| from_gate_operand(qubit, context))
-                .collect();
+            let gate_operands = barrier.qubit_list().map(|operands| {
+                operands
+                    .gate_operands()
+                    .map(|qubit| from_gate_operand(qubit, context))
+                    .collect()
+            });
             Some(asg::Stmt::Barrier(asg::Barrier::new(gate_operands)))
         }
 


### PR DESCRIPTION
Closes #58