### PR TITLE
Make path-based inputs generic of `AsRef<Path>`

### DIFF
--- a/crates/oq3_semantics/examples/semdemo.rs
+++ b/crates/oq3_semantics/examples/semdemo.rs
@@ -82,7 +82,8 @@ fn main() {
         Some(Commands::SemanticString { file_name }) => {
             let source = read_example_source(file_name);
             let file_name = Some("giraffe");
-            let result = syntax_to_semantics::parse_source_string(source, file_name, None);
+            let result =
+                syntax_to_semantics::parse_source_string(source, file_name, None::<&[PathBuf]>);
             if result.any_errors() {
                 result.print_errors();
             }
@@ -91,7 +92,7 @@ fn main() {
 
         #[allow(clippy::dbg_macro)]
         Some(Commands::Semantic { file_name }) => {
-            let result = syntax_to_semantics::parse_source_file(file_name, None);
+            let result = syntax_to_semantics::parse_source_file(file_name, None::<&[PathBuf]>);
             let have_errors = result.any_errors();
             if have_errors {
                 println!("Found errors: {}", have_errors);
@@ -106,7 +107,7 @@ fn main() {
         }
 
         Some(Commands::SemanticPretty { file_name }) => {
-            let result = syntax_to_semantics::parse_source_file(file_name, None);
+            let result = syntax_to_semantics::parse_source_file(file_name, None::<&[PathBuf]>);
             println!("Found errors: {}", result.any_errors());
             result.print_errors();
             result.program().print_asg_debug_pretty();
@@ -118,7 +119,7 @@ fn main() {
         //     context.program().print_asg_debug_pretty();
         // }
         Some(Commands::Parse { file_name }) => {
-            let parsed_source = oq3_source_file::parse_source_file(file_name, None);
+            let parsed_source = oq3_source_file::parse_source_file(file_name, None::<&[PathBuf]>);
             let parse_tree = parsed_source.syntax_ast().tree();
             println!(
                 "Found {} items",

--- a/crates/oq3_semantics/src/syntax_to_semantics.rs
+++ b/crates/oq3_semantics/src/syntax_to_semantics.rs
@@ -10,7 +10,7 @@
 
 use std;
 use std::mem::replace;
-use std::path::PathBuf;
+use std::path::Path;
 
 use crate::asg;
 use crate::types;
@@ -87,21 +87,29 @@ impl ParseResult<SourceString> {
 
 /// Parse string containing source to semantic ASG.
 /// Fake file name is used for printing diagnostics.
-pub fn parse_source_string<T: ToString>(
+pub fn parse_source_string<T, P>(
     source: T,
     fake_file_path: Option<&str>,
-    search_path_list: Option<&Vec<PathBuf>>,
-) -> ParseResult<SourceString> {
+    search_path_list: Option<&[P]>,
+) -> ParseResult<SourceString>
+where
+    T: AsRef<str>,
+    P: AsRef<Path>,
+{
     let parsed_source =
         oq3_source_file::parse_source_string(source, fake_file_path, search_path_list);
     analyze_source(parsed_source)
 }
 
 /// Parse source file to semantic ASG
-pub fn parse_source_file(
-    file_path: &PathBuf,
-    search_path_list: Option<&Vec<PathBuf>>,
-) -> ParseResult<SourceFile> {
+pub fn parse_source_file<T, P>(
+    file_path: T,
+    search_path_list: Option<&[P]>,
+) -> ParseResult<SourceFile>
+where
+    T: AsRef<Path>,
+    P: AsRef<Path>,
+{
     let parsed_source = oq3_source_file::parse_source_file(file_path, search_path_list);
     analyze_source(parsed_source)
 }

--- a/crates/oq3_semantics/tests/from_string_tests.rs
+++ b/crates/oq3_semantics/tests/from_string_tests.rs
@@ -8,7 +8,7 @@ use oq3_semantics::syntax_to_semantics::parse_source_string;
 use oq3_semantics::types::{ArrayDims, IsConst, Type};
 
 fn parse_string(code: &str) -> (asg::Program, SemanticErrorList, SymbolTable) {
-    parse_source_string(code, None, None)
+    parse_source_string(code, None, None::<&[&std::path::Path]>)
         .take_context()
         .as_tuple()
 }

--- a/crates/oq3_source_file/src/api.rs
+++ b/crates/oq3_source_file/src/api.rs
@@ -13,16 +13,17 @@ use std::path::{Path, PathBuf};
 
 use crate::source_file::{
     expand_path, parse_source_and_includes, range_to_span, read_source_file, ErrorTrait,
-    Normalizeable, SourceFile, SourceString,
+    SourceFile, SourceString,
 };
 
 /// Read source from `file_path` and parse to the syntactic AST.
 /// Parse and store included files recursively.
-pub fn parse_source_file(
-    file_path: &PathBuf,
-    search_path_list: Option<&Vec<PathBuf>>,
-) -> SourceFile {
-    let full_path = expand_path(file_path, search_path_list).normalize();
+pub fn parse_source_file<T, P>(file_path: T, search_path_list: Option<&[P]>) -> SourceFile
+where
+    T: AsRef<Path>,
+    P: AsRef<Path>,
+{
+    let full_path = expand_path(file_path, search_path_list);
     let (syntax_ast, included) =
         parse_source_and_includes(read_source_file(&full_path).as_str(), search_path_list);
     SourceFile::new(full_path, syntax_ast, included)
@@ -30,13 +31,17 @@ pub fn parse_source_file(
 
 /// Read source from `file_path` and parse to the syntactic AST.
 /// Parse and store included files recursively.
-pub fn parse_source_string<T: ToString>(
+pub fn parse_source_string<T, P>(
     source: T,
     fake_file_path: Option<&str>,
-    search_path_list: Option<&Vec<PathBuf>>,
-) -> SourceString {
-    let source = source.to_string();
-    let (syntax_ast, included) = parse_source_and_includes(source.as_str(), search_path_list);
+    search_path_list: Option<&[P]>,
+) -> SourceString
+where
+    T: AsRef<str>,
+    P: AsRef<Path>,
+{
+    let source = source.as_ref();
+    let (syntax_ast, included) = parse_source_and_includes(source, search_path_list);
     let fake_file_path = PathBuf::from(fake_file_path.unwrap_or("no file"));
     SourceString::new(source, fake_file_path, syntax_ast, included)
 }


### PR DESCRIPTION
This simplifies calling code from outside the library in various places; various components no longer need to be compelled or recollected into the exact typing that the input requires, but instead can be used in anything that can be treated as a path slice.

---

When calling from Qiskit side, it's quite inconvenient to re-collect everything I get natively as `str` or whatever from Python space into an owning `PathBuf`, where it's already interpretable via reference into a `Path`-like (`OsString` is a superset of `String` for use in file-system access, and `OsString: AsRef<Path>` since `Path` is give-or-take a wrapper around `&OsStr` (which in turn is to `OsString` as `&str` is to `String`)).