### PR TITLE
Bump version from 0.0.6 to 0.0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.0.6"
+version = "0.0.7"
 rust-version = "1.70"
 edition = "2021"
 license = "Apache-2.0"
@@ -15,8 +15,8 @@ repository = "https://github.com/Qiskit/openqasm3_parser"
 
 [workspace.dependencies]
 # local crates
-oq3_lexer = { path = "crates/oq3_lexer", version = "0.0.6" }
-oq3_parser = { path = "crates/oq3_parser", version = "0.0.6" }
-oq3_syntax = { path = "crates/oq3_syntax", version = "0.0.6" }
-oq3_semantics = { path = "crates/oq3_semantics", version = "0.0.6" }
-oq3_source_file = { path = "crates/oq3_source_file", version = "0.0.6" }
+oq3_lexer = { path = "crates/oq3_lexer", version = "0.0.7" }
+oq3_parser = { path = "crates/oq3_parser", version = "0.0.7" }
+oq3_syntax = { path = "crates/oq3_syntax", version = "0.0.7" }
+oq3_semantics = { path = "crates/oq3_semantics", version = "0.0.7" }
+oq3_source_file = { path = "crates/oq3_source_file", version = "0.0.7" }


### PR DESCRIPTION
This release fixes a few bugs and reworks how gate modifiers are implemented. Gate modifiers are represented in the ASG as a field in `GateCall` containing a Vec of modifiers.

* The change since the last version 0.0.6 is in a single PR: #86