### PR TITLE
Release the first minor version 0.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,5 +25,5 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       - run: date
-      - run: sleep 120
+      - run: sleep 60
       - run: date

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.0.7"
+version = "0.1.0"
 rust-version = "1.70"
 edition = "2021"
 license = "Apache-2.0"
@@ -15,8 +15,8 @@ repository = "https://github.com/Qiskit/openqasm3_parser"
 
 [workspace.dependencies]
 # local crates
-oq3_lexer = { path = "crates/oq3_lexer", version = "0.0.7" }
-oq3_parser = { path = "crates/oq3_parser", version = "0.0.7" }
-oq3_syntax = { path = "crates/oq3_syntax", version = "0.0.7" }
-oq3_semantics = { path = "crates/oq3_semantics", version = "0.0.7" }
-oq3_source_file = { path = "crates/oq3_source_file", version = "0.0.7" }
+oq3_lexer = { path = "crates/oq3_lexer", version = "0.1.0" }
+oq3_parser = { path = "crates/oq3_parser", version = "0.1.0" }
+oq3_syntax = { path = "crates/oq3_syntax", version = "0.1.0" }
+oq3_semantics = { path = "crates/oq3_semantics", version = "0.1.0" }
+oq3_source_file = { path = "crates/oq3_source_file", version = "0.1.0" }


### PR DESCRIPTION
This allows packages to depend on the minor version and still be compatible with patch versions.