### PR TITLE
Interpret PrefixExpr of literal ints and floats into ASG

### DIFF
--- a/crates/oq3_semantics/src/asg.rs
+++ b/crates/oq3_semantics/src/asg.rs
@@ -782,19 +782,24 @@ impl BoolLiteral {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct IntLiteral {
     value: u128,
+    sign: bool,
 }
 
 impl IntLiteral {
-    pub fn new<T>(value: T) -> IntLiteral
+    pub fn new<T>(value: T, sign: bool) -> IntLiteral
     where
         T: Into<u128>,
     {
         let x: u128 = value.into();
-        IntLiteral { value: x }
+        IntLiteral { value: x, sign }
     }
 
     pub fn value(&self) -> &u128 {
         &self.value
+    }
+
+    pub fn sign(&self) -> &bool {
+        &self.sign
     }
 
     pub fn to_expr(self) -> Expr {

--- a/crates/oq3_semantics/tests/ast_tests.rs
+++ b/crates/oq3_semantics/tests/ast_tests.rs
@@ -28,7 +28,7 @@ fn test_texpr_int_literal() {
     use asg::IntLiteral;
     use types::{IsConst, Type};
 
-    let literal = IntLiteral::new(1_u32);
+    let literal = IntLiteral::new(1_u32, true);
     let texpr = literal.clone().to_texpr();
     assert_eq!(texpr.expression(), &literal.to_expr());
     assert_eq!(texpr.get_type(), &Type::UInt(Some(128), IsConst::True));
@@ -47,7 +47,7 @@ fn test_int_literal() {
     use asg::IntLiteral;
 
     let int_value = 42;
-    let literal = IntLiteral::new(int_value as u32);
+    let literal = IntLiteral::new(int_value as u32, true);
     assert_eq!(*literal.value(), int_value as u128);
 }
 
@@ -75,7 +75,7 @@ fn test_cast() {
     use types::{IsConst, Type};
 
     let typ = Type::Int(Some(32), IsConst::True);
-    let literal = IntLiteral::new(1_u64).to_texpr();
+    let literal = IntLiteral::new(1_u64, true).to_texpr();
     let cast = Cast::new(literal.clone(), typ.clone());
     assert_eq!(cast.get_type(), &typ);
     assert_eq!(cast.operand(), &literal);

--- a/crates/oq3_syntax/openqasm3.ungram
+++ b/crates/oq3_syntax/openqasm3.ungram
@@ -209,6 +209,7 @@ Expr =
 | MeasureExpression
 | ModifiedGateCallExpr
 | ParenExpr
+| PrefixExpr
 | RangeExpr
 | ReturnExpr
 
@@ -242,6 +243,9 @@ BlockExpr =
   '{'
     statements:Stmt*
   '}'
+
+PrefixExpr =
+    op:('~' | '!' | '-') Expr
 
 // Adding a binary op here requires changes in several places. See notes at the top of this file.
 BinExpr =

--- a/crates/oq3_syntax/src/ast/expr_ext.rs
+++ b/crates/oq3_syntax/src/ast/expr_ext.rs
@@ -8,7 +8,7 @@
 use crate::{
     ast::{
         self,
-        operators::{ArithOp, BinaryOp, CmpOp, LogicOp, Ordering},
+        operators::{ArithOp, BinaryOp, CmpOp, LogicOp, Ordering, UnaryOp},
         support, AstChildren, AstNode,
     },
     AstToken,
@@ -146,6 +146,22 @@ impl ast::IfStmt {
 //     };
 //     assert_eq!(else_.syntax().text(), r#"{ "else" }"#);
 // }
+
+impl ast::PrefixExpr {
+    pub fn op_kind(&self) -> Option<UnaryOp> {
+        let res = match self.op_token()?.kind() {
+            T![~] => UnaryOp::LogicNot,
+            T![!] => UnaryOp::Not,
+            T![-] => UnaryOp::Neg,
+            _ => return None,
+        };
+        Some(res)
+    }
+
+    pub fn op_token(&self) -> Option<SyntaxToken> {
+        self.syntax().first_child_or_token()?.into_token()
+    }
+}
 
 impl ast::BinExpr {
     pub fn op_details(&self) -> Option<(SyntaxToken, BinaryOp)> {

--- a/crates/oq3_syntax/src/ast/generated/nodes.rs
+++ b/crates/oq3_syntax/src/ast/generated/nodes.rs
@@ -664,6 +664,15 @@ impl ParenExpr {
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PrefixExpr {
+    pub(crate) syntax: SyntaxNode,
+}
+impl PrefixExpr {
+    pub fn expr(&self) -> Option<Expr> {
+        support::child(&self.syntax)
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct RangeExpr {
     pub(crate) syntax: SyntaxNode,
 }
@@ -1058,6 +1067,7 @@ pub enum Expr {
     MeasureExpression(MeasureExpression),
     ModifiedGateCallExpr(ModifiedGateCallExpr),
     ParenExpr(ParenExpr),
+    PrefixExpr(PrefixExpr),
     RangeExpr(RangeExpr),
     ReturnExpr(ReturnExpr),
 }
@@ -1834,6 +1844,21 @@ impl AstNode for ParenExpr {
         &self.syntax
     }
 }
+impl AstNode for PrefixExpr {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        kind == PREFIX_EXPR
+    }
+    fn cast(syntax: SyntaxNode) -> Option<Self> {
+        if Self::can_cast(syntax.kind()) {
+            Some(Self { syntax })
+        } else {
+            None
+        }
+    }
+    fn syntax(&self) -> &SyntaxNode {
+        &self.syntax
+    }
+}
 impl AstNode for RangeExpr {
     fn can_cast(kind: SyntaxKind) -> bool {
         kind == RANGE_EXPR
@@ -2425,6 +2450,11 @@ impl From<ParenExpr> for Expr {
         Expr::ParenExpr(node)
     }
 }
+impl From<PrefixExpr> for Expr {
+    fn from(node: PrefixExpr) -> Expr {
+        Expr::PrefixExpr(node)
+    }
+}
 impl From<RangeExpr> for Expr {
     fn from(node: RangeExpr) -> Expr {
         Expr::RangeExpr(node)
@@ -2455,6 +2485,7 @@ impl AstNode for Expr {
                 | MEASURE_EXPRESSION
                 | MODIFIED_GATE_CALL_EXPR
                 | PAREN_EXPR
+                | PREFIX_EXPR
                 | RANGE_EXPR
                 | RETURN_EXPR
         )
@@ -2477,6 +2508,7 @@ impl AstNode for Expr {
             MEASURE_EXPRESSION => Expr::MeasureExpression(MeasureExpression { syntax }),
             MODIFIED_GATE_CALL_EXPR => Expr::ModifiedGateCallExpr(ModifiedGateCallExpr { syntax }),
             PAREN_EXPR => Expr::ParenExpr(ParenExpr { syntax }),
+            PREFIX_EXPR => Expr::PrefixExpr(PrefixExpr { syntax }),
             RANGE_EXPR => Expr::RangeExpr(RangeExpr { syntax }),
             RETURN_EXPR => Expr::ReturnExpr(ReturnExpr { syntax }),
             _ => return None,
@@ -2501,6 +2533,7 @@ impl AstNode for Expr {
             Expr::MeasureExpression(it) => &it.syntax,
             Expr::ModifiedGateCallExpr(it) => &it.syntax,
             Expr::ParenExpr(it) => &it.syntax,
+            Expr::PrefixExpr(it) => &it.syntax,
             Expr::RangeExpr(it) => &it.syntax,
             Expr::ReturnExpr(it) => &it.syntax,
         }
@@ -2974,6 +3007,11 @@ impl std::fmt::Display for ModifiedGateCallExpr {
     }
 }
 impl std::fmt::Display for ParenExpr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl std::fmt::Display for PrefixExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(self.syntax(), f)
     }

--- a/crates/oq3_syntax/src/ast/operators.rs
+++ b/crates/oq3_syntax/src/ast/operators.rs
@@ -17,8 +17,8 @@ pub enum RangeOp {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum UnaryOp {
-    /// `*`
-    Deref,
+    /// `~`
+    LogicNot,
     /// `!`
     Not,
     /// `-`

--- a/crates/oq3_syntax/src/ast/prec.rs
+++ b/crates/oq3_syntax/src/ast/prec.rs
@@ -137,7 +137,7 @@ impl Expr {
             }
             ArrayLiteral(_) => (0, 0), // These need to be checked
             MeasureExpression(_) => (0, 0),
-            BoxExpr(_) => (0, 27),
+            BoxExpr(_) | PrefixExpr(_) => (0, 27),
             GateCallExpr(_)
             | ModifiedGateCallExpr(_)
             | CallExpr(_)
@@ -191,6 +191,7 @@ impl Expr {
             // For non-paren-like operators: get the operator itself
             let token = match this {
                 RangeExpr(_) => None,
+                PrefixExpr(e) => e.op_token(),
                 BinExpr(e) => e.op_token(),
                 BoxExpr(e) => e.box_token(),
                 CallExpr(e) => e.arg_list().and_then(|args| args.l_paren_token()),
@@ -241,7 +242,7 @@ impl Expr {
             | ParenExpr(_) => false,
 
             // For BinExpr and RangeExpr this is technically wrong -- the child can be on the left...
-            BinExpr(_) | RangeExpr(_) | BoxExpr(_) | ReturnExpr(_) => self
+            PrefixExpr(_) | BinExpr(_) | RangeExpr(_) | BoxExpr(_) | ReturnExpr(_) => self
                 .syntax()
                 .parent()
                 .and_then(Expr::cast)


### PR DESCRIPTION
This correctly parses and analyzes to ASG some expressions representing negative numeric literals. At the same time it does not incorrectly parse binary expressions such as `a-1.23` The following (should!) enter the ASG correctly:
`1.23;`
`-1.23;`
`- 1.23;`
`1;`
`-1;`
`- 1`;

Some tests for all of the items above (and the binary expression) are included in this commit.

There are a few ugly things. But maybe they can be fixed later.

This PR also should make it easier to do anoether PR to handle variables with unary minus.

The access (API) to the ASG, tries to be backward compatible. Probably could used a simple redesign.

* A new accessor `sign()` is added to `IntLiteral`. For positive values `sign()` returns `true`, for negative `false`.

* `FloatLiteral` is still a `String` and the possible `-` sign is formatted into the string. We talked about storing an f64 here instead. Probably would be a good option. But the present API is backward compatible.