### PR TITLE
Support `asg::Expr::UnaryExpr(UnaryExpr)` for `UnaryOp::Minus`

### DIFF
--- a/crates/oq3_semantics/src/asg.rs
+++ b/crates/oq3_semantics/src/asg.rs
@@ -921,6 +921,16 @@ impl UnaryExpr {
     pub fn op(&self) -> &UnaryOp {
         &self.op
     }
+
+    pub fn to_texpr(self) -> TExpr {
+        match self.op() {
+            UnaryOp::Not => TExpr::new(Expr::UnaryExpr(self), Type::Bool(IsConst::False)),
+            _ => {
+                let ty = self.operand.get_type().clone();
+                TExpr::new(Expr::UnaryExpr(self), ty)
+            }
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/crates/oq3_semantics/tests/from_string_tests.rs
+++ b/crates/oq3_semantics/tests/from_string_tests.rs
@@ -371,6 +371,17 @@ fn literal_value(stmt: &asg::Stmt) -> Option<String> {
 }
 
 #[test]
+fn test_from_string_unary_minus() {
+    let code = r##"
+- a;
+"##;
+    let (program, errors, _symbol_table) = parse_string(code);
+    assert_eq!(errors.len(), 1);
+    let expr = expr_from_expr_stmt(&program[0]);
+    assert!(matches!(&expr, asg::Expr::UnaryExpr(_)));
+}
+
+#[test]
 fn test_from_string_pos_lit_float() {
     let code = r##"
 1.23;


### PR DESCRIPTION
This supports in the ASG unary expressions with `UnaryOp::Minus`

The struct `UnaryExpr` and accessors were already present. Now we construct these from the AST.

* See #81

Now expressions (or statements) like
```
gate rx(t) q {}
angle t;
qubit q;

rx(-t) q;
```
should enter the ASG correctly
```
GateCall(GateCall { 
  name: Ok(SymbolId(9)),

  params: Some([TExpr { 
    expression: UnaryExpr(UnaryExpr { op: Minus, operand: TExpr { expression: Identifier(Identifier { name: "t", symbol: Ok(SymbolId(10)) }), ty: Angle(None, False) } }), 
    ty: Angle(None, False) }]),

  qubits: [TExpr { expression: GateOperand(Identifier(Identifier { name: "q", symbol: Ok(SymbolId(11)) })), ty: Qubit }], 

  modifiers: [] }

)
```

Closes #81