### PR TITLE
Record syntax error instead of panicing when no block found

### DIFF
--- a/crates/oq3_parser/src/grammar/expressions.rs
+++ b/crates/oq3_parser/src/grammar/expressions.rs
@@ -5,7 +5,7 @@ pub mod atom;
 
 use super::*;
 
-pub(crate) use atom::block_expr;
+pub(crate) use atom::try_block_expr;
 pub(super) use atom::LITERAL_FIRST;
 // Pretty sure semicolon is always required in OQ3
 #[derive(PartialEq, Eq)]

--- a/crates/oq3_parser/src/grammar/expressions/atom.rs
+++ b/crates/oq3_parser/src/grammar/expressions/atom.rs
@@ -308,47 +308,6 @@ fn array_expr(p: &mut Parser<'_>) -> CompletedMarker {
 //     m.complete(p, SET_EXPR)
 // }
 
-// test if_expr
-// fn foo() {
-//     if true {};
-//     if true {} else {};
-//     if true {} else if false {} else {};
-//     if S {};
-//     if { true } { } else { };
-// }
-// moved to items.rs
-// fn if_expr(p: &mut Parser<'_>) -> CompletedMarker {
-//     assert!(p.at(T![if]));
-//     let m = p.start();
-//     p.bump(T![if]);
-//     expr_no_struct(p);
-//     block_expr(p);
-//     if p.at(T![else]) {
-//         p.bump(T![else]);
-//         if p.at(T![if]) {
-//             if_expr(p);
-//         } else {
-//             block_expr(p);
-//         }
-//     }
-//     m.complete(p, IF_STMT)
-// }
-
-// test while_expr
-// fn foo() {
-//     while true {};
-//     while let Some(x) = it.next() {};
-//     while { true } {};
-// }
-// fn while_expr(p: &mut Parser<'_>, m: Option<Marker>) -> CompletedMarker {
-//     assert!(p.at(T![while]));
-//     let m = m.unwrap_or_else(|| p.start());
-//     p.bump(T![while]);
-//     expr_no_struct(p);
-//     block_expr(p);
-//     m.complete(p, WHILE_STMT)
-// }
-
 // test for_expr
 // fn foo() {
 //     for x in [] {};
@@ -364,6 +323,14 @@ fn for_expr(p: &mut Parser<'_>, m: Option<Marker>) -> CompletedMarker {
     m.complete(p, FOR_STMT)
 }
 
+pub(crate) fn try_block_expr(p: &mut Parser<'_>) {
+    if !p.at(T!['{']) {
+        p.error("expected a block");
+        return;
+    }
+    let _ = block_expr(p);
+}
+
 pub(crate) fn block_expr(p: &mut Parser<'_>) -> CompletedMarker {
     // FIXME: can't use this check in refactor.
     // get this working again.
@@ -374,7 +341,6 @@ pub(crate) fn block_expr(p: &mut Parser<'_>) -> CompletedMarker {
     assert!(p.at(T!['{']));
     let m = p.start();
     p.bump(T!['{']);
-    // read until T!['}']
     expr_block_contents(p);
     p.expect(T!['}']);
     m.complete(p, BLOCK_EXPR)

--- a/crates/oq3_parser/src/grammar/items.rs
+++ b/crates/oq3_parser/src/grammar/items.rs
@@ -106,18 +106,18 @@ fn switch_case_stmt(p: &mut Parser<'_>, m: Marker) {
     expressions::expr_no_struct(p);
     p.expect(T![')']);
     p.expect(T!['{']);
-    if ! p.at(T![case]) {
+    if !p.at(T![case]) {
         p.error("expecting `case` keyword");
     }
     while p.at(T![case]) {
         let m1 = p.start();
         p.bump(T![case]);
         params::expression_list(p);
-        expressions::block_expr(p);
+        expressions::try_block_expr(p);
         m1.complete(p, CASE_EXPR);
     }
     if p.eat(T![default]) {
-        expressions::block_expr(p);
+        expressions::try_block_expr(p);
     }
     p.expect(T!['}']);
     m.complete(p, SWITCH_CASE_STMT);
@@ -129,14 +129,14 @@ fn if_stmt(p: &mut Parser<'_>, m: Marker) {
     p.expect(T!['(']);
     expressions::expr_no_struct(p);
     p.expect(T![')']);
-    expressions::block_expr(p);
+    expressions::try_block_expr(p);
     if p.at(T![else]) {
         p.bump(T![else]);
         if p.at(T![if]) {
             let m = p.start();
             if_stmt(p, m);
         } else {
-            expressions::block_expr(p);
+            expressions::try_block_expr(p);
         }
     }
     m.complete(p, IF_STMT);
@@ -148,7 +148,7 @@ fn while_stmt(p: &mut Parser<'_>, m: Marker) {
     p.expect(T!['(']);
     expressions::expr_no_struct(p);
     p.expect(T![')']);
-    expressions::block_expr(p);
+    expressions::try_block_expr(p);
     m.complete(p, WHILE_STMT);
 }
 
@@ -284,7 +284,7 @@ fn gate_definition(p: &mut Parser<'_>, m: Marker) {
     // Read the list of qubit parameters
     params::param_list_gate_qubits(p);
     // Read the code block.
-    expressions::block_expr(p);
+    expressions::try_block_expr(p);
     // Mark this attempt at reading an item as complete.
     m.complete(p, GATE);
 }
@@ -305,7 +305,7 @@ fn defcal_(p: &mut Parser<'_>, m: Marker) {
 
     opt_ret_type(p);
     // Read the code block.
-    expressions::block_expr(p);
+    expressions::try_block_expr(p);
     // Mark this attempt at reading an item as complete.
     m.complete(p, DEF_CAL);
 }
@@ -324,7 +324,7 @@ fn def_(p: &mut Parser<'_>, m: Marker) {
     }
     opt_ret_type(p);
     // Read the code block.
-    expressions::block_expr(p);
+    expressions::try_block_expr(p);
     // Mark this attempt at reading an item as complete.
     m.complete(p, DEF);
 }
@@ -358,7 +358,7 @@ fn include(p: &mut Parser<'_>, m: Marker) {
 // Should we implement recovery?
 fn cal_(p: &mut Parser<'_>, m: Marker) {
     p.bump(T![cal]);
-    expressions::block_expr(p);
+    expressions::try_block_expr(p);
     m.complete(p, CAL);
 }
 

--- a/crates/oq3_semantics/src/asg.rs
+++ b/crates/oq3_semantics/src/asg.rs
@@ -1154,8 +1154,16 @@ pub struct SwitchCaseStmt {
 }
 
 impl SwitchCaseStmt {
-    pub fn new(control: TExpr, cases: Vec<CaseExpr>, default_block: Option<Vec<Stmt>>) -> SwitchCaseStmt {
-        SwitchCaseStmt { control, cases, default_block }
+    pub fn new(
+        control: TExpr,
+        cases: Vec<CaseExpr>,
+        default_block: Option<Vec<Stmt>>,
+    ) -> SwitchCaseStmt {
+        SwitchCaseStmt {
+            control,
+            cases,
+            default_block,
+        }
     }
 
     pub fn control(&self) -> &TExpr {

--- a/crates/oq3_semantics/src/syntax_to_semantics.rs
+++ b/crates/oq3_semantics/src/syntax_to_semantics.rs
@@ -227,7 +227,10 @@ fn from_stmt(stmt: synast::Stmt, context: &mut Context) -> Option<asg::Stmt> {
             with_scope!(context,  ScopeType::Local,
                         let default_statements = switch_case_stmt.default_block().map(|block| statement_list_from_block(block, context));
             );
-            Some(asg::SwitchCaseStmt::new(control.unwrap(), case_exprs, default_statements).to_stmt())
+            Some(
+                asg::SwitchCaseStmt::new(control.unwrap(), case_exprs, default_statements)
+                    .to_stmt(),
+            )
         }
 
         synast::Stmt::ClassicalDeclarationStatement(type_decl) => {
@@ -701,12 +704,13 @@ fn from_literal(literal: &synast::Literal) -> Option<asg::TExpr> {
     Some(literal_texpr)
 }
 
-
 // Convert a block of statements in the AST to a list of ASG statements
 // We don't convert to asg::Block, because these lists of statements go into
 // other block-like structures as well.
 fn statement_list_from_block(block: synast::BlockExpr, context: &mut Context) -> Vec<asg::Stmt> {
-    block.statements().map(|syn_stmt| from_stmt(syn_stmt, context).unwrap())
+    block
+        .statements()
+        .map(|syn_stmt| from_stmt(syn_stmt, context).unwrap())
         .collect::<Vec<_>>()
 }
 

--- a/crates/oq3_semantics/tests/from_string_tests.rs
+++ b/crates/oq3_semantics/tests/from_string_tests.rs
@@ -532,10 +532,7 @@ switch(c) {
     let (program, errors, _symbol_table) = parse_string(code);
     assert_eq!(errors.len(), 0);
     assert_eq!(program.len(), 2);
-    assert!(matches!(
-        &program[1],
-        asg::Stmt::SwitchCaseStmt(_)
-    ));
+    assert!(matches!(&program[1], asg::Stmt::SwitchCaseStmt(_)));
 }
 
 #[test]
@@ -555,8 +552,5 @@ int x = 3;
     let (program, errors, _symbol_table) = parse_string(code);
     assert_eq!(errors.len(), 0);
     assert_eq!(program.len(), 3);
-    assert!(matches!(
-        &program[1],
-        asg::Stmt::SwitchCaseStmt(_)
-    ));
+    assert!(matches!(&program[1], asg::Stmt::SwitchCaseStmt(_)));
 }


### PR DESCRIPTION
Before this PR, if we expect a block, beginning with `{`, the parser panics. Now it logs an appropriate syntax error.

It could use better recovery. Because later errors are logged which essentially say the same thing. But analyzing the cases for recovery may take a bit of logic.

Closes #107