### PR TITLE
Remove two obsolete, never-used methods in asg.rs

### DIFF
--- a/crates/oq3_semantics/src/asg.rs
+++ b/crates/oq3_semantics/src/asg.rs
@@ -524,14 +524,6 @@ impl GateDeclaration {
         }
     }
 
-    pub fn new_empty_qubit_list() -> Vec<SymbolIdResult> {
-        Vec::<SymbolIdResult>::new()
-    }
-
-    pub fn new_empty_param_list() -> Vec<SymbolIdResult> {
-        Vec::<SymbolIdResult>::new()
-    }
-
     pub fn to_stmt(self) -> Stmt {
         Stmt::GateDeclaration(self)
     }


### PR DESCRIPTION
Removing two methods.
`new_empty_qubit_list` and `new_empty_param_list` were present to support some idea that was never implemented.

Closes #112
