### PR TITLE
Remove unused method implementing From trait

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,4 +41,4 @@ jobs:
     - name: Build
       run: cargo build --release --verbose
     - name: Run tests
-      run: cargo test --verbose -- --skip sourcegen_ast --skip sourcegen_ast_nodes
+      run: cargo test --verbose --lib --tests -- --skip sourcegen_ast --skip sourcegen_ast_nodes

--- a/crates/oq3_semantics/Cargo.toml
+++ b/crates/oq3_semantics/Cargo.toml
@@ -22,6 +22,6 @@ rowan = "0.15.11"
 boolenum = "0.1"
 
 [dev-dependencies]
-clap = { version = "4.0", features = ["derive"] }
+clap = { version = "4.4", features = ["derive"] }
 oq3_lexer.workspace = true
 oq3_parser.workspace = true

--- a/crates/oq3_semantics/Cargo.toml
+++ b/crates/oq3_semantics/Cargo.toml
@@ -22,6 +22,6 @@ rowan = "0.15.11"
 boolenum = "0.1"
 
 [dev-dependencies]
-clap = { version = "4.4", features = ["derive"] }
+clap = { version = "4.4.15", features = ["derive"] }
 oq3_lexer.workspace = true
 oq3_parser.workspace = true

--- a/crates/oq3_semantics/Cargo.toml
+++ b/crates/oq3_semantics/Cargo.toml
@@ -22,6 +22,6 @@ rowan = "0.15.11"
 boolenum = "0.1"
 
 [dev-dependencies]
-clap = { version = "4.4.15", features = ["derive"] }
+clap = { version = "~4.4", features = ["derive"] }
 oq3_lexer.workspace = true
 oq3_parser.workspace = true

--- a/crates/oq3_semantics/src/symbols.rs
+++ b/crates/oq3_semantics/src/symbols.rs
@@ -53,14 +53,6 @@ impl Default for SymbolId {
     }
 }
 
-// I'd rather keep the implementation and value secret.
-// But Python. This is useful for the pyo3 consumer.
-impl From<SymbolId> for usize {
-    fn from(symid: SymbolId) -> usize {
-        symid.0
-    }
-}
-
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum SymbolError {
     MissingBinding,

--- a/crates/oq3_syntax/Cargo.toml
+++ b/crates/oq3_syntax/Cargo.toml
@@ -37,5 +37,5 @@ expect-test = "1.4.0"
 proc-macro2 = "1.0.47"
 quote = "1.0.20"
 ungrammar = "1.16.1"
-clap = { version = "4.4.15", features = ["derive"] }
+clap = { version = "~4.4", features = ["derive"] }
 

--- a/crates/oq3_syntax/Cargo.toml
+++ b/crates/oq3_syntax/Cargo.toml
@@ -37,5 +37,5 @@ expect-test = "1.4.0"
 proc-macro2 = "1.0.47"
 quote = "1.0.20"
 ungrammar = "1.16.1"
-clap = { version = "4.0", features = ["derive"] }
+clap = { version = "4.4", features = ["derive"] }
 

--- a/crates/oq3_syntax/Cargo.toml
+++ b/crates/oq3_syntax/Cargo.toml
@@ -37,5 +37,5 @@ expect-test = "1.4.0"
 proc-macro2 = "1.0.47"
 quote = "1.0.20"
 ungrammar = "1.16.1"
-clap = { version = "4.4", features = ["derive"] }
+clap = { version = "4.4.15", features = ["derive"] }
 

--- a/crates/oq3_syntax/examples/demoparse.rs
+++ b/crates/oq3_syntax/examples/demoparse.rs
@@ -11,7 +11,7 @@ use oq3_syntax::{ast, parse_text, GreenNode, SourceFile};
 use rowan::NodeOrToken; // TODO: this can be accessed from a higher level
 
 #[derive(Parser)]
-#[command(name = "demotest")]
+#[command(name = "demoparse")]
 #[command(about = "Demo of parser that parses and prints tokens or trees to stdout.")]
 #[command(long_about = "
 Demo of parser that parses and prints tokens or trees to stdout.

--- a/local_CI.sh
+++ b/local_CI.sh
@@ -6,4 +6,4 @@
 cargo fmt --all -- --check || exit 1
 cargo build --release --verbose || exit 1
 cargo clippy --all-targets -- -D warnings -D clippy::dbg_macro || exit 1
-cargo test --verbose -- --skip sourcegen_ast --skip sourcegen_ast_nodes || exit 1
+cargo test --verbose --lib --tests -- --skip sourcegen_ast --skip sourcegen_ast_nodes || exit 1

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -7,4 +7,4 @@
 # are breaking the source. Or may break it.
 # r-a uses some system to control this that we have not, and may never, set up.
 
-cargo test -- --skip sourcegen_ast --skip sourcegen_ast_nodes
+cargo test --lib --tests -- --skip sourcegen_ast --skip sourcegen_ast_nodes

--- a/run_tests_less.sh
+++ b/run_tests_less.sh
@@ -9,4 +9,4 @@
 # are breaking the source. Or may break it.
 # r-a uses some system to control this that we have not, and may never, set up.
 
-cargo test --color always -- --skip sourcegen_ast --skip sourcegen_ast_nodes |& less -R
+cargo test --lib --tests --color always -- --skip sourcegen_ast --skip sourcegen_ast_nodes |& less -R


### PR DESCRIPTION
This was used in an obsolete, experimental, pyo3 interface. Might be needed in the future, but not now.

Closes #76