### PR TITLE
Don't assume all statements in block are converted to `Some` in ASG

### DIFF
--- a/crates/oq3_semantics/src/syntax_to_semantics.rs
+++ b/crates/oq3_semantics/src/syntax_to_semantics.rs
@@ -710,7 +710,7 @@ fn from_literal(literal: &synast::Literal) -> Option<asg::TExpr> {
 fn statement_list_from_block(block: synast::BlockExpr, context: &mut Context) -> Vec<asg::Stmt> {
     block
         .statements()
-        .map(|syn_stmt| from_stmt(syn_stmt, context).unwrap())
+        .filter_map(|syn_stmt| from_stmt(syn_stmt, context))
         .collect::<Vec<_>>()
 }
 


### PR DESCRIPTION
In particular, `include` in local scope records an error and returns `None`.

Closes #101