### PR TITLE
Check fix clippy lint in test

### DIFF
--- a/crates/oq3_lexer/src/tests.rs
+++ b/crates/oq3_lexer/src/tests.rs
@@ -4,13 +4,13 @@
 use super::*;
 
 use expect_test::{expect, Expect};
+use std::fmt::Write;
 
-// FIXME: Probably do what clippy asks for here
-#[allow(clippy::format_collect)]
 fn check_lexing(src: &str, expect: Expect) {
-    let actual: String = tokenize(src)
-        .map(|token| format!("{:?}\n", token))
-        .collect();
+    let actual: String = tokenize(src).fold(String::new(), |mut output, token| {
+        let _ = writeln!(output, "{token:?}");
+        output
+    });
     expect.assert_eq(&actual)
 }
 

--- a/crates/oq3_semantics/Cargo.toml
+++ b/crates/oq3_semantics/Cargo.toml
@@ -17,7 +17,7 @@ doctest = false
 [dependencies]
 oq3_source_file.workspace = true
 oq3_syntax.workspace = true
-hashbrown = { version = "0.14" }
+hashbrown = { version = "0.12.3" }
 rowan = "0.15.11"
 boolenum = "0.1"
 

--- a/crates/oq3_syntax/Cargo.toml
+++ b/crates/oq3_syntax/Cargo.toml
@@ -27,6 +27,7 @@ smol_str = "0.2.0"
 stdx = { version = "0.0.188", package = "ra_ap_stdx"}
 triomphe = { version = "0.1.8", default-features = false, features = ["std"] }
 xshell = "0.2.2"
+rustversion = "1.0"
 # local crates
 oq3_lexer.workspace = true
 oq3_parser.workspace = true

--- a/crates/oq3_syntax/src/ptr.rs
+++ b/crates/oq3_syntax/src/ptr.rs
@@ -32,6 +32,14 @@ pub struct AstPtr<N: AstNode> {
 }
 
 impl<N: AstNode> Clone for AstPtr<N> {
+    #[rustversion::before(1.74)]
+    fn clone(&self) -> AstPtr<N> {
+        AstPtr {
+            raw: self.raw.clone(),
+            _ty: PhantomData,
+        }
+    }
+    #[rustversion::since(1.74)]
     fn clone(&self) -> AstPtr<N> {
         AstPtr {
             raw: self.raw,
@@ -67,8 +75,14 @@ impl<N: AstNode> AstPtr<N> {
         N::cast(syntax_node).unwrap()
     }
 
+    #[rustversion::since(1.74)]
     pub fn syntax_node_ptr(&self) -> SyntaxNodePtr {
         self.raw
+    }
+
+    #[rustversion::before(1.74)]
+    pub fn syntax_node_ptr(&self) -> SyntaxNodePtr {
+        self.raw.clone()
     }
 
     pub fn text_range(&self) -> TextRange {


### PR DESCRIPTION
The main point of this PR is to try to avoid frequent CI failures due to `ahash` incompatibility with rustc 1.70.


This removes a clippy lint overrride that does not exist in the rust 1.70 toolchain.
This PR passes local CI with both 1.70 and 1.75.
However, 1.70 fails in GH CI because an attempt is made to install a  version of ahash that does not support rust 1.70.

I have not yet discovered why this does not happen locally.

I'll use this PR to push a bunch of commits to try to troubleshoot the CI failure a bit.
