### PR TITLE
Implement `return`

### DIFF
--- a/crates/oq3_semantics/src/asg.rs
+++ b/crates/oq3_semantics/src/asg.rs
@@ -130,6 +130,7 @@ pub enum Expr {
     // But we need to handle these in a consistent way. Is there any situation where the "type" of Range is meaningful or useful?
     // For example, in syntax_to_semantics, have a routine that handles out-of-tree expressions.
     Range(Range),
+    Return(Box<ReturnExpression>),
     Call, // stub function (def) call
     Set,  // stub
     MeasureExpression(MeasureExpression),
@@ -197,7 +198,6 @@ pub enum Stmt {
     OldStyleDeclaration, // stub
     Pragma(Pragma),
     Reset(Reset),
-    Return, // stub
     SwitchCaseStmt(SwitchCaseStmt),
     While(While),
 }
@@ -291,6 +291,25 @@ impl IndexExpression {
 
     pub fn to_texpr(self) -> TExpr {
         TExpr::new(Expr::IndexExpression(self), Type::ToDo)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ReturnExpression {
+    value: Option<TExpr>,
+}
+
+impl ReturnExpression {
+    pub fn new(value: Option<TExpr>) -> ReturnExpression {
+        ReturnExpression { value }
+    }
+
+    pub fn to_texpr(self) -> TExpr {
+        TExpr::new(Expr::Return(Box::new(self)), Type::ToDo)
+    }
+
+    pub fn value(&self) -> Option<&TExpr> {
+        self.value.as_ref()
     }
 }
 

--- a/crates/oq3_semantics/src/asg.rs
+++ b/crates/oq3_semantics/src/asg.rs
@@ -305,7 +305,11 @@ impl ReturnExpression {
     }
 
     pub fn to_texpr(self) -> TExpr {
-        TExpr::new(Expr::Return(Box::new(self)), Type::ToDo)
+        let return_type = match self.value() {
+            Some(expr) => expr.get_type().clone(),
+            _ => Type::Void,
+        };
+        TExpr::new(Expr::Return(Box::new(self)), return_type)
     }
 
     pub fn value(&self) -> Option<&TExpr> {

--- a/crates/oq3_semantics/src/semantic_error.rs
+++ b/crates/oq3_semantics/src/semantic_error.rs
@@ -21,6 +21,7 @@ pub enum SemanticErrorKind {
     IncompatibleTypesError,
     MutateConstError,
     IncludeNotInGlobalScopeError,
+    ReturnInGlobalScopeError,
     NumGateParamsError,
     NumGateQubitsError,
 }

--- a/crates/oq3_semantics/src/syntax_to_semantics.rs
+++ b/crates/oq3_semantics/src/syntax_to_semantics.rs
@@ -520,6 +520,9 @@ fn from_expr(expr_maybe: Option<synast::Expr>, context: &mut Context) -> Option<
 
         synast::Expr::ReturnExpr(ref return_expr) => {
             let expr_asg = from_expr(return_expr.expr(), context);
+            if context.symbol_table().current_scope_type() == ScopeType::Global {
+                context.insert_error(ReturnInGlobalScopeError, &expr);
+            }
             Some(asg::ReturnExpression::new(expr_asg).to_texpr())
         }
 


### PR DESCRIPTION
### Breaking recursion in `enum Expr` done differently here 
Note that in `enum Expr` in asg.rs, variants before this PR have looked like this:
https://github.com/Qiskit/openqasm3_parser/blob/b174b2b80af8a06aa1a855798e41fa2d6e554ee9/crates/oq3_semantics/src/asg.rs#L118-L121

For `return` expressions we introduce a variant `Return(Box<ReturnExpression>)`. This probably means that consumers have to treat `Return` differently because the indirection happens in a different place (in the variant). The other choice would be to continue with the previous pattern of putting the `Box` in the struct `ReturnExpression`.

It probably makes sense to choose one way and do it uniformly.

### Change in `fn from_expr` in `syntax_to_semantics.rs`

Before the expression from the AST was unwrapped and passed to `from_expr`. This is changed in this PR. Now we pass the `Option` to `from_expr`. This simplifies much code in syntax_to_semantics.rs (as is evident by looking at this PR). `panic`s due to `unwrap` will be moved to different places in the code. Of course, eventually, we need to avoid panic ing altogether.

Note that there is a check for `return` in global scope. But we need something more systematic than this
* See #136

Closes #133