### PR TITLE
Implement pragma end to end

### DIFF
--- a/crates/oq3_parser/src/grammar/expressions.rs
+++ b/crates/oq3_parser/src/grammar/expressions.rs
@@ -96,6 +96,11 @@ pub(crate) fn stmt(p: &mut Parser<'_>, semicolon: Semicolon) {
         Ok(()) => return,
         Err(m) => m,
     };
+    if p.at(PRAGMA) {
+        p.bump_any();
+        m.complete(p, PRAGMA_STATEMENT);
+        return;
+    }
     // FIXME: straighten out logic
     if !(p.current().is_classical_type() && (p.nth(1) == T!['('] || p.nth(1) == T!['[']))
         && !p.at_ts(EXPR_FIRST)

--- a/crates/oq3_parser/src/grammar/expressions.rs
+++ b/crates/oq3_parser/src/grammar/expressions.rs
@@ -8,13 +8,6 @@ use super::*;
 pub(crate) use atom::block_expr;
 pub(crate) use atom::try_block_expr;
 pub(super) use atom::LITERAL_FIRST;
-// Pretty sure semicolon is always required in OQ3
-#[derive(PartialEq, Eq)]
-pub(crate) enum Semicolon {
-    Required,
-    // Optional,
-    // Forbidden,
-}
 
 const EXPR_FIRST: TokenSet = LHS_FIRST;
 
@@ -77,13 +70,13 @@ pub(crate) fn expr_no_struct(p: &mut Parser<'_>) {
 }
 
 // GJL made public. remove visibility
-pub(crate) fn stmt(p: &mut Parser<'_>, semicolon: Semicolon) {
+pub(crate) fn stmt(p: &mut Parser<'_>) {
     if p.eat(T![;]) {
         return;
     }
     if p.at(T![let]) {
         let m = p.start();
-        let_stmt(p, m, semicolon);
+        let_stmt(p, m);
         return;
     }
     // if p.current().is_type_name() {
@@ -118,17 +111,6 @@ pub(crate) fn stmt(p: &mut Parser<'_>, semicolon: Semicolon) {
             } else {
                 p.expect(T![;]);
             }
-            // Can we use the following for pragmas in OQ3?
-            // In the rest of OQ3, semicolons are always required.
-            // match semicolon {
-            //     Semicolon::Required => {
-            //         if blocklike.is_block() {
-            //             p.eat(T![;]);
-            //         } else {
-            //             p.expect(T![;]);
-            //         }
-            //     }
-            // }
             // Assignment is a statement, not an expression.
             // So we do not wrap it in EXPR_STMT.
             if cm_kind == ASSIGNMENT_STMT {
@@ -145,16 +127,12 @@ pub(crate) fn stmt(p: &mut Parser<'_>, semicolon: Semicolon) {
     // But OQ3 only supports let as statment.
     // FIXME: "fn let_expr" is implemented in atom.rs as well. I think this is a mistake.
     // It should appear once.
-    fn let_stmt(p: &mut Parser<'_>, m: Marker, with_semi: Semicolon) {
+    fn let_stmt(p: &mut Parser<'_>, m: Marker) {
         p.bump(T![let]);
         p.expect(IDENT);
         p.expect(T![=]);
         expressions::expr(p);
-        match with_semi {
-            Semicolon::Required => {
-                p.expect(T![;]);
-            }
-        }
+        p.expect(T![;]);
         m.complete(p, LET_STMT);
     }
 }
@@ -165,7 +143,7 @@ pub(crate) fn stmt(p: &mut Parser<'_>, semicolon: Semicolon) {
 // This function exists in r-a, but it is not called without having read a {
 pub(super) fn expr_block_contents(p: &mut Parser<'_>) {
     while !p.at(EOF) && !p.at(T!['}']) {
-        stmt(p, Semicolon::Required);
+        stmt(p);
     }
 }
 

--- a/crates/oq3_parser/src/grammar/items.rs
+++ b/crates/oq3_parser/src/grammar/items.rs
@@ -175,7 +175,7 @@ fn for_stmt(p: &mut Parser<'_>, m: Marker) {
     if p.at(T!['{']) {
         expressions::block_expr(p);
     } else {
-        expressions::stmt(p, expressions::Semicolon::Required);
+        expressions::stmt(p);
     }
     m.complete(p, FOR_STMT);
 }

--- a/crates/oq3_parser/src/lexed_str.rs
+++ b/crates/oq3_parser/src/lexed_str.rs
@@ -259,6 +259,8 @@ fn inner_extend_token<'a>(
                 IDENT
             }
 
+            oq3_lexer::TokenKind::Pragma => PRAGMA,
+
             oq3_lexer::TokenKind::Literal { kind, .. } => {
                 //                    self.extend_literal(token_text.len(), kind);
                 return extend_literal_func(token_text.len(), kind);

--- a/crates/oq3_parser/src/syntax_kind/syntax_kind_enum.rs
+++ b/crates/oq3_parser/src/syntax_kind/syntax_kind_enum.rs
@@ -66,6 +66,7 @@ pub enum SyntaxKind {
     #[doc = r" all_keywords"]
     O_P_E_N_Q_A_S_M_KW,
     INCLUDE_KW,
+    PRAGMA_KW,
     DEF_KW,
     DEFCALGRAMMAR_KW,
     CAL_KW,
@@ -74,7 +75,6 @@ pub enum SyntaxKind {
     DELAY_KW,
     RESET_KW,
     MEASURE_KW,
-    PRAGMA_KW,
     LET_KW,
     BOX_KW,
     EXTERN_KW,
@@ -134,6 +134,7 @@ pub enum SyntaxKind {
     HARDWAREIDENT,
     WHITESPACE,
     COMMENT,
+    PRAGMA,
     #[doc = r" nodes"]
     SOURCE_FILE,
     GATE,
@@ -145,6 +146,7 @@ pub enum SyntaxKind {
     DEF,
     RESET,
     CONST,
+    PRAGMA_STATEMENT,
     TUPLE_EXPR,
     ARRAY_EXPR,
     PAREN_EXPR,
@@ -222,6 +224,7 @@ impl SyntaxKind {
             self,
             O_P_E_N_Q_A_S_M_KW
                 | INCLUDE_KW
+                | PRAGMA_KW
                 | DEF_KW
                 | DEFCALGRAMMAR_KW
                 | CAL_KW
@@ -230,7 +233,6 @@ impl SyntaxKind {
                 | DELAY_KW
                 | RESET_KW
                 | MEASURE_KW
-                | PRAGMA_KW
                 | LET_KW
                 | BOX_KW
                 | EXTERN_KW
@@ -356,6 +358,7 @@ impl SyntaxKind {
         let kw = match ident {
             "OPENQASM" => O_P_E_N_Q_A_S_M_KW,
             "include" => INCLUDE_KW,
+            "pragma" => PRAGMA_KW,
             "def" => DEF_KW,
             "defcalgrammar" => DEFCALGRAMMAR_KW,
             "cal" => CAL_KW,
@@ -364,7 +367,6 @@ impl SyntaxKind {
             "delay" => DELAY_KW,
             "reset" => RESET_KW,
             "measure" => MEASURE_KW,
-            "pragma" => PRAGMA_KW,
             "let" => LET_KW,
             "box" => BOX_KW,
             "extern" => EXTERN_KW,
@@ -453,5 +455,5 @@ impl SyntaxKind {
     }
 }
 #[macro_export]
-macro_rules ! T { [++] => { $ crate :: SyntaxKind :: DOUBLE_PLUS } ; [;] => { $ crate :: SyntaxKind :: SEMICOLON } ; [,] => { $ crate :: SyntaxKind :: COMMA } ; ['('] => { $ crate :: SyntaxKind :: L_PAREN } ; [')'] => { $ crate :: SyntaxKind :: R_PAREN } ; ['{'] => { $ crate :: SyntaxKind :: L_CURLY } ; ['}'] => { $ crate :: SyntaxKind :: R_CURLY } ; ['['] => { $ crate :: SyntaxKind :: L_BRACK } ; [']'] => { $ crate :: SyntaxKind :: R_BRACK } ; [<] => { $ crate :: SyntaxKind :: L_ANGLE } ; [>] => { $ crate :: SyntaxKind :: R_ANGLE } ; [@] => { $ crate :: SyntaxKind :: AT } ; [#] => { $ crate :: SyntaxKind :: POUND } ; [~] => { $ crate :: SyntaxKind :: TILDE } ; [?] => { $ crate :: SyntaxKind :: QUESTION } ; [$] => { $ crate :: SyntaxKind :: DOLLAR } ; [&] => { $ crate :: SyntaxKind :: AMP } ; [|] => { $ crate :: SyntaxKind :: PIPE } ; [+] => { $ crate :: SyntaxKind :: PLUS } ; [*] => { $ crate :: SyntaxKind :: STAR } ; [/] => { $ crate :: SyntaxKind :: SLASH } ; [^] => { $ crate :: SyntaxKind :: CARET } ; [%] => { $ crate :: SyntaxKind :: PERCENT } ; [_] => { $ crate :: SyntaxKind :: UNDERSCORE } ; [.] => { $ crate :: SyntaxKind :: DOT } ; [..] => { $ crate :: SyntaxKind :: DOT2 } ; [...] => { $ crate :: SyntaxKind :: DOT3 } ; [..=] => { $ crate :: SyntaxKind :: DOT2EQ } ; [:] => { $ crate :: SyntaxKind :: COLON } ; [::] => { $ crate :: SyntaxKind :: COLON2 } ; [=] => { $ crate :: SyntaxKind :: EQ } ; [==] => { $ crate :: SyntaxKind :: EQ2 } ; [=>] => { $ crate :: SyntaxKind :: FAT_ARROW } ; [!] => { $ crate :: SyntaxKind :: BANG } ; [!=] => { $ crate :: SyntaxKind :: NEQ } ; [-] => { $ crate :: SyntaxKind :: MINUS } ; [->] => { $ crate :: SyntaxKind :: THIN_ARROW } ; [<=] => { $ crate :: SyntaxKind :: LTEQ } ; [>=] => { $ crate :: SyntaxKind :: GTEQ } ; [+=] => { $ crate :: SyntaxKind :: PLUSEQ } ; [-=] => { $ crate :: SyntaxKind :: MINUSEQ } ; [|=] => { $ crate :: SyntaxKind :: PIPEEQ } ; [&=] => { $ crate :: SyntaxKind :: AMPEQ } ; [^=] => { $ crate :: SyntaxKind :: CARETEQ } ; [/=] => { $ crate :: SyntaxKind :: SLASHEQ } ; [*=] => { $ crate :: SyntaxKind :: STAREQ } ; [%=] => { $ crate :: SyntaxKind :: PERCENTEQ } ; [&&] => { $ crate :: SyntaxKind :: AMP2 } ; [||] => { $ crate :: SyntaxKind :: PIPE2 } ; [<<] => { $ crate :: SyntaxKind :: SHL } ; [>>] => { $ crate :: SyntaxKind :: SHR } ; [<<=] => { $ crate :: SyntaxKind :: SHLEQ } ; [>>=] => { $ crate :: SyntaxKind :: SHREQ } ; [OPENQASM] => { $ crate :: SyntaxKind :: O_P_E_N_Q_A_S_M_KW } ; [include] => { $ crate :: SyntaxKind :: INCLUDE_KW } ; [def] => { $ crate :: SyntaxKind :: DEF_KW } ; [defcalgrammar] => { $ crate :: SyntaxKind :: DEFCALGRAMMAR_KW } ; [cal] => { $ crate :: SyntaxKind :: CAL_KW } ; [defcal] => { $ crate :: SyntaxKind :: DEFCAL_KW } ; [gate] => { $ crate :: SyntaxKind :: GATE_KW } ; [delay] => { $ crate :: SyntaxKind :: DELAY_KW } ; [reset] => { $ crate :: SyntaxKind :: RESET_KW } ; [measure] => { $ crate :: SyntaxKind :: MEASURE_KW } ; [pragma] => { $ crate :: SyntaxKind :: PRAGMA_KW } ; [let] => { $ crate :: SyntaxKind :: LET_KW } ; [box] => { $ crate :: SyntaxKind :: BOX_KW } ; [extern] => { $ crate :: SyntaxKind :: EXTERN_KW } ; [const] => { $ crate :: SyntaxKind :: CONST_KW } ; [barrier] => { $ crate :: SyntaxKind :: BARRIER_KW } ; [gphase] => { $ crate :: SyntaxKind :: GPHASE_KW } ; [if] => { $ crate :: SyntaxKind :: IF_KW } ; [else] => { $ crate :: SyntaxKind :: ELSE_KW } ; [for] => { $ crate :: SyntaxKind :: FOR_KW } ; [in] => { $ crate :: SyntaxKind :: IN_KW } ; [while] => { $ crate :: SyntaxKind :: WHILE_KW } ; [continue] => { $ crate :: SyntaxKind :: CONTINUE_KW } ; [return] => { $ crate :: SyntaxKind :: RETURN_KW } ; [break] => { $ crate :: SyntaxKind :: BREAK_KW } ; [end] => { $ crate :: SyntaxKind :: END_KW } ; [switch] => { $ crate :: SyntaxKind :: SWITCH_KW } ; [case] => { $ crate :: SyntaxKind :: CASE_KW } ; [default] => { $ crate :: SyntaxKind :: DEFAULT_KW } ; [input] => { $ crate :: SyntaxKind :: INPUT_KW } ; [output] => { $ crate :: SyntaxKind :: OUTPUT_KW } ; [readonly] => { $ crate :: SyntaxKind :: READONLY_KW } ; [mutable] => { $ crate :: SyntaxKind :: MUTABLE_KW } ; [qreg] => { $ crate :: SyntaxKind :: QREG_KW } ; [creg] => { $ crate :: SyntaxKind :: CREG_KW } ; [qubit] => { $ crate :: SyntaxKind :: QUBIT_KW } ; [void] => { $ crate :: SyntaxKind :: VOID_KW } ; [array] => { $ crate :: SyntaxKind :: ARRAY_KW } ; [ctrl] => { $ crate :: SyntaxKind :: CTRL_KW } ; [negctrl] => { $ crate :: SyntaxKind :: NEGCTRL_KW } ; [inv] => { $ crate :: SyntaxKind :: INV_KW } ; [pow] => { $ crate :: SyntaxKind :: POW_KW } ; [false] => { $ crate :: SyntaxKind :: FALSE_KW } ; [true] => { $ crate :: SyntaxKind :: TRUE_KW } ; [float] => { $ crate :: SyntaxKind :: FLOAT_TY } ; [int] => { $ crate :: SyntaxKind :: INT_TY } ; [uint] => { $ crate :: SyntaxKind :: UINT_TY } ; [complex] => { $ crate :: SyntaxKind :: COMPLEX_TY } ; [bool] => { $ crate :: SyntaxKind :: BOOL_TY } ; [bit] => { $ crate :: SyntaxKind :: BIT_TY } ; [duration] => { $ crate :: SyntaxKind :: DURATION_TY } ; [stretch] => { $ crate :: SyntaxKind :: STRETCH_TY } ; [angle] => { $ crate :: SyntaxKind :: ANGLE_TY } ; [ident] => { $ crate :: SyntaxKind :: IDENT } ; }
+macro_rules ! T { [++] => { $ crate :: SyntaxKind :: DOUBLE_PLUS } ; [;] => { $ crate :: SyntaxKind :: SEMICOLON } ; [,] => { $ crate :: SyntaxKind :: COMMA } ; ['('] => { $ crate :: SyntaxKind :: L_PAREN } ; [')'] => { $ crate :: SyntaxKind :: R_PAREN } ; ['{'] => { $ crate :: SyntaxKind :: L_CURLY } ; ['}'] => { $ crate :: SyntaxKind :: R_CURLY } ; ['['] => { $ crate :: SyntaxKind :: L_BRACK } ; [']'] => { $ crate :: SyntaxKind :: R_BRACK } ; [<] => { $ crate :: SyntaxKind :: L_ANGLE } ; [>] => { $ crate :: SyntaxKind :: R_ANGLE } ; [@] => { $ crate :: SyntaxKind :: AT } ; [#] => { $ crate :: SyntaxKind :: POUND } ; [~] => { $ crate :: SyntaxKind :: TILDE } ; [?] => { $ crate :: SyntaxKind :: QUESTION } ; [$] => { $ crate :: SyntaxKind :: DOLLAR } ; [&] => { $ crate :: SyntaxKind :: AMP } ; [|] => { $ crate :: SyntaxKind :: PIPE } ; [+] => { $ crate :: SyntaxKind :: PLUS } ; [*] => { $ crate :: SyntaxKind :: STAR } ; [/] => { $ crate :: SyntaxKind :: SLASH } ; [^] => { $ crate :: SyntaxKind :: CARET } ; [%] => { $ crate :: SyntaxKind :: PERCENT } ; [_] => { $ crate :: SyntaxKind :: UNDERSCORE } ; [.] => { $ crate :: SyntaxKind :: DOT } ; [..] => { $ crate :: SyntaxKind :: DOT2 } ; [...] => { $ crate :: SyntaxKind :: DOT3 } ; [..=] => { $ crate :: SyntaxKind :: DOT2EQ } ; [:] => { $ crate :: SyntaxKind :: COLON } ; [::] => { $ crate :: SyntaxKind :: COLON2 } ; [=] => { $ crate :: SyntaxKind :: EQ } ; [==] => { $ crate :: SyntaxKind :: EQ2 } ; [=>] => { $ crate :: SyntaxKind :: FAT_ARROW } ; [!] => { $ crate :: SyntaxKind :: BANG } ; [!=] => { $ crate :: SyntaxKind :: NEQ } ; [-] => { $ crate :: SyntaxKind :: MINUS } ; [->] => { $ crate :: SyntaxKind :: THIN_ARROW } ; [<=] => { $ crate :: SyntaxKind :: LTEQ } ; [>=] => { $ crate :: SyntaxKind :: GTEQ } ; [+=] => { $ crate :: SyntaxKind :: PLUSEQ } ; [-=] => { $ crate :: SyntaxKind :: MINUSEQ } ; [|=] => { $ crate :: SyntaxKind :: PIPEEQ } ; [&=] => { $ crate :: SyntaxKind :: AMPEQ } ; [^=] => { $ crate :: SyntaxKind :: CARETEQ } ; [/=] => { $ crate :: SyntaxKind :: SLASHEQ } ; [*=] => { $ crate :: SyntaxKind :: STAREQ } ; [%=] => { $ crate :: SyntaxKind :: PERCENTEQ } ; [&&] => { $ crate :: SyntaxKind :: AMP2 } ; [||] => { $ crate :: SyntaxKind :: PIPE2 } ; [<<] => { $ crate :: SyntaxKind :: SHL } ; [>>] => { $ crate :: SyntaxKind :: SHR } ; [<<=] => { $ crate :: SyntaxKind :: SHLEQ } ; [>>=] => { $ crate :: SyntaxKind :: SHREQ } ; [OPENQASM] => { $ crate :: SyntaxKind :: O_P_E_N_Q_A_S_M_KW } ; [include] => { $ crate :: SyntaxKind :: INCLUDE_KW } ; [pragma] => { $ crate :: SyntaxKind :: PRAGMA_KW } ; [def] => { $ crate :: SyntaxKind :: DEF_KW } ; [defcalgrammar] => { $ crate :: SyntaxKind :: DEFCALGRAMMAR_KW } ; [cal] => { $ crate :: SyntaxKind :: CAL_KW } ; [defcal] => { $ crate :: SyntaxKind :: DEFCAL_KW } ; [gate] => { $ crate :: SyntaxKind :: GATE_KW } ; [delay] => { $ crate :: SyntaxKind :: DELAY_KW } ; [reset] => { $ crate :: SyntaxKind :: RESET_KW } ; [measure] => { $ crate :: SyntaxKind :: MEASURE_KW } ; [let] => { $ crate :: SyntaxKind :: LET_KW } ; [box] => { $ crate :: SyntaxKind :: BOX_KW } ; [extern] => { $ crate :: SyntaxKind :: EXTERN_KW } ; [const] => { $ crate :: SyntaxKind :: CONST_KW } ; [barrier] => { $ crate :: SyntaxKind :: BARRIER_KW } ; [gphase] => { $ crate :: SyntaxKind :: GPHASE_KW } ; [if] => { $ crate :: SyntaxKind :: IF_KW } ; [else] => { $ crate :: SyntaxKind :: ELSE_KW } ; [for] => { $ crate :: SyntaxKind :: FOR_KW } ; [in] => { $ crate :: SyntaxKind :: IN_KW } ; [while] => { $ crate :: SyntaxKind :: WHILE_KW } ; [continue] => { $ crate :: SyntaxKind :: CONTINUE_KW } ; [return] => { $ crate :: SyntaxKind :: RETURN_KW } ; [break] => { $ crate :: SyntaxKind :: BREAK_KW } ; [end] => { $ crate :: SyntaxKind :: END_KW } ; [switch] => { $ crate :: SyntaxKind :: SWITCH_KW } ; [case] => { $ crate :: SyntaxKind :: CASE_KW } ; [default] => { $ crate :: SyntaxKind :: DEFAULT_KW } ; [input] => { $ crate :: SyntaxKind :: INPUT_KW } ; [output] => { $ crate :: SyntaxKind :: OUTPUT_KW } ; [readonly] => { $ crate :: SyntaxKind :: READONLY_KW } ; [mutable] => { $ crate :: SyntaxKind :: MUTABLE_KW } ; [qreg] => { $ crate :: SyntaxKind :: QREG_KW } ; [creg] => { $ crate :: SyntaxKind :: CREG_KW } ; [qubit] => { $ crate :: SyntaxKind :: QUBIT_KW } ; [void] => { $ crate :: SyntaxKind :: VOID_KW } ; [array] => { $ crate :: SyntaxKind :: ARRAY_KW } ; [ctrl] => { $ crate :: SyntaxKind :: CTRL_KW } ; [negctrl] => { $ crate :: SyntaxKind :: NEGCTRL_KW } ; [inv] => { $ crate :: SyntaxKind :: INV_KW } ; [pow] => { $ crate :: SyntaxKind :: POW_KW } ; [false] => { $ crate :: SyntaxKind :: FALSE_KW } ; [true] => { $ crate :: SyntaxKind :: TRUE_KW } ; [float] => { $ crate :: SyntaxKind :: FLOAT_TY } ; [int] => { $ crate :: SyntaxKind :: INT_TY } ; [uint] => { $ crate :: SyntaxKind :: UINT_TY } ; [complex] => { $ crate :: SyntaxKind :: COMPLEX_TY } ; [bool] => { $ crate :: SyntaxKind :: BOOL_TY } ; [bit] => { $ crate :: SyntaxKind :: BIT_TY } ; [duration] => { $ crate :: SyntaxKind :: DURATION_TY } ; [stretch] => { $ crate :: SyntaxKind :: STRETCH_TY } ; [angle] => { $ crate :: SyntaxKind :: ANGLE_TY } ; [ident] => { $ crate :: SyntaxKind :: IDENT } ; }
 pub use T;

--- a/crates/oq3_semantics/src/asg.rs
+++ b/crates/oq3_semantics/src/asg.rs
@@ -721,6 +721,10 @@ impl Reset {
     pub fn gate_operand(&self) -> &TExpr {
         &self.gate_operand
     }
+
+    pub fn to_stmt(self) -> Stmt {
+        Stmt::Reset(self)
+    }
 }
 
 // This is one of several examples where instead of `enum Literal`
@@ -1281,17 +1285,21 @@ impl CaseExpr {
 // Might make sense for this, and others to be like `struct Pragma(String)`.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Pragma {
-    pragma: String,
+    pragma_text: String,
 }
 
 impl Pragma {
     pub fn new<T: ToString>(pragma: T) -> Pragma {
         Pragma {
-            pragma: pragma.to_string(),
+            pragma_text: pragma.to_string(),
         }
     }
 
     pub fn pragma(&self) -> &str {
-        self.pragma.as_ref()
+        self.pragma_text.as_ref()
+    }
+
+    pub fn to_stmt(self) -> Stmt {
+        Stmt::Pragma(self)
     }
 }

--- a/crates/oq3_semantics/src/asg.rs
+++ b/crates/oq3_semantics/src/asg.rs
@@ -1295,7 +1295,8 @@ impl Pragma {
         }
     }
 
-    pub fn pragma(&self) -> &str {
+    /// Return the pragma line omitting the directive "pragma" or "#pragma"
+    pub fn pragma_text(&self) -> &str {
         self.pragma_text.as_ref()
     }
 

--- a/crates/oq3_semantics/src/syntax_to_semantics.rs
+++ b/crates/oq3_semantics/src/syntax_to_semantics.rs
@@ -357,7 +357,7 @@ fn from_stmt(stmt: synast::Stmt, context: &mut Context) -> Option<asg::Stmt> {
         synast::Stmt::Reset(reset) => {
             let gate_operand = reset.gate_operand().unwrap(); // FIXME: check this
             let gate_operand_asg = from_gate_operand(gate_operand, context);
-            Some(asg::Stmt::Reset(asg::Reset::new(gate_operand_asg)))
+            Some(asg::Reset::new(gate_operand_asg).to_stmt())
         }
 
         synast::Stmt::Include(include) => {
@@ -376,6 +376,10 @@ fn from_stmt(stmt: synast::Stmt, context: &mut Context) -> Option<asg::Stmt> {
             let version = version_string.version().unwrap().version().unwrap();
             let _ = version.split_into_parts();
             None
+        }
+
+        synast::Stmt::PragmaStatement(pragma) => {
+            Some(asg::Pragma::new(pragma.pragma_text()).to_stmt())
         }
 
         _ => None,

--- a/crates/oq3_syntax/openqasm3.ungram
+++ b/crates/oq3_syntax/openqasm3.ungram
@@ -48,7 +48,7 @@
 // Names  //
 //********//
 
-// Some apparent tokes, such as 'ident' are intercepted in sourcegen_ast.rs and are
+// Some apparent tokens, such as 'ident' are intercepted in sourcegen_ast.rs and are
 // treated specially.
 Name =
   'ident'
@@ -87,6 +87,11 @@ Stmt =
 | TypeDeclarationStmt
 | VersionString
 | WhileStmt
+| PragmaStatement
+
+// Like 'ident' the remainder is manually coded
+PragmaStatement =
+   'pragma'
 
 SwitchCaseStmt =
     'switch' '(' control:Expr ')' '{' (CaseExpr*) ('default' default_block:BlockExpr)? '}'

--- a/crates/oq3_syntax/src/ast/generated/nodes.rs
+++ b/crates/oq3_syntax/src/ast/generated/nodes.rs
@@ -448,6 +448,15 @@ impl WhileStmt {
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PragmaStatement {
+    pub(crate) syntax: SyntaxNode,
+}
+impl PragmaStatement {
+    pub fn pragma_token(&self) -> Option<SyntaxToken> {
+        support::token(&self.syntax, T![pragma])
+    }
+}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CaseExpr {
     pub(crate) syntax: SyntaxNode,
 }
@@ -1067,6 +1076,7 @@ pub enum Stmt {
     TypeDeclarationStmt(TypeDeclarationStmt),
     VersionString(VersionString),
     WhileStmt(WhileStmt),
+    PragmaStatement(PragmaStatement),
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Expr {
@@ -1497,6 +1507,21 @@ impl AstNode for VersionString {
 impl AstNode for WhileStmt {
     fn can_cast(kind: SyntaxKind) -> bool {
         kind == WHILE_STMT
+    }
+    fn cast(syntax: SyntaxNode) -> Option<Self> {
+        if Self::can_cast(syntax.kind()) {
+            Some(Self { syntax })
+        } else {
+            None
+        }
+    }
+    fn syntax(&self) -> &SyntaxNode {
+        &self.syntax
+    }
+}
+impl AstNode for PragmaStatement {
+    fn can_cast(kind: SyntaxKind) -> bool {
+        kind == PRAGMA_STATEMENT
     }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         if Self::can_cast(syntax.kind()) {
@@ -2274,6 +2299,11 @@ impl From<WhileStmt> for Stmt {
         Stmt::WhileStmt(node)
     }
 }
+impl From<PragmaStatement> for Stmt {
+    fn from(node: PragmaStatement) -> Stmt {
+        Stmt::PragmaStatement(node)
+    }
+}
 impl AstNode for Stmt {
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
@@ -2302,6 +2332,7 @@ impl AstNode for Stmt {
                 | TYPE_DECLARATION_STMT
                 | VERSION_STRING
                 | WHILE_STMT
+                | PRAGMA_STATEMENT
         )
     }
     fn cast(syntax: SyntaxNode) -> Option<Self> {
@@ -2336,6 +2367,7 @@ impl AstNode for Stmt {
             TYPE_DECLARATION_STMT => Stmt::TypeDeclarationStmt(TypeDeclarationStmt { syntax }),
             VERSION_STRING => Stmt::VersionString(VersionString { syntax }),
             WHILE_STMT => Stmt::WhileStmt(WhileStmt { syntax }),
+            PRAGMA_STATEMENT => Stmt::PragmaStatement(PragmaStatement { syntax }),
             _ => return None,
         };
         Some(res)
@@ -2366,6 +2398,7 @@ impl AstNode for Stmt {
             Stmt::TypeDeclarationStmt(it) => &it.syntax,
             Stmt::VersionString(it) => &it.syntax,
             Stmt::WhileStmt(it) => &it.syntax,
+            Stmt::PragmaStatement(it) => &it.syntax,
         }
     }
 }
@@ -2864,6 +2897,11 @@ impl std::fmt::Display for VersionString {
     }
 }
 impl std::fmt::Display for WhileStmt {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.syntax(), f)
+    }
+}
+impl std::fmt::Display for PragmaStatement {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(self.syntax(), f)
     }

--- a/crates/oq3_syntax/src/ast/node_ext.rs
+++ b/crates/oq3_syntax/src/ast/node_ext.rs
@@ -136,3 +136,19 @@ impl ast::HasLoopBody for ast::WhileStmt {
         second.or(first)
     }
 }
+
+impl ast::PragmaStatement {
+    fn text(&self) -> TokenText<'_> {
+        text_of_first_token(self.syntax())
+    }
+
+    // return the pragma line omitting the word "pragma"
+    pub fn pragma_text(&self) -> String {
+        let text = self.text();
+        if text.starts_with('#') {
+            text[7..].to_string()
+        } else {
+            text[6..].to_string()
+        }
+    }
+}

--- a/crates/oq3_syntax/src/tests/ast_src.rs
+++ b/crates/oq3_syntax/src/tests/ast_src.rs
@@ -71,6 +71,7 @@ pub(crate) const KINDS_SRC: KindsSrc<'_> = KindsSrc {
     keywords: &[
         "OPENQASM",
         "include",
+        "pragma",
         "def",
         "defcalgrammar",
         "cal",
@@ -79,7 +80,6 @@ pub(crate) const KINDS_SRC: KindsSrc<'_> = KindsSrc {
         "delay",
         "reset",
         "measure",
-        "pragma",
         "let",
         "box",
         "extern",
@@ -135,7 +135,14 @@ pub(crate) const KINDS_SRC: KindsSrc<'_> = KindsSrc {
         "TIMING_FLOAT_NUMBER",
         "TIMING_INT_NUMBER",
     ],
-    tokens: &["ERROR", "IDENT", "HARDWAREIDENT", "WHITESPACE", "COMMENT"],
+    tokens: &[
+        "ERROR",
+        "IDENT",
+        "HARDWAREIDENT",
+        "WHITESPACE",
+        "COMMENT",
+        "PRAGMA",
+    ],
     nodes: &[
         "SOURCE_FILE",
         "GATE",
@@ -147,6 +154,7 @@ pub(crate) const KINDS_SRC: KindsSrc<'_> = KindsSrc {
         "DEF",
         "RESET",
         "CONST",
+        "PRAGMA_STATEMENT",
         // atoms
         "TUPLE_EXPR",
         "ARRAY_EXPR",

--- a/crates/oq3_syntax/src/tests/sourcegen_ast.rs
+++ b/crates/oq3_syntax/src/tests/sourcegen_ast.rs
@@ -795,17 +795,6 @@ fn lower_rule(acc: &mut Vec<Field>, grammar: &Grammar, label: Option<&String>, r
             // This is a list of labels that are used in openqasm3.ungram (modified from list in in rust-analyzer)
             // There are typically functions with the same name as the label that are defined in files named
             // *_ext.rs.
-            // Consider this fragment of an ungram rule:
-            //
-            // IfExpr =
-            //    Attr* 'if' condition:Expr then_branch:BlockExpr
-            //
-            // This is handled in expr_ext.rs by
-            //
-            // impl ast::IfExpr {
-            //    pub fn condition(... ...
-            //    pub fn then_branch(...
-            //
             let manually_implemented = matches!(
                 l.as_str(),
                 "lhs"


### PR DESCRIPTION
This did not fit neatly in the ungrammar scheme.
There are a lot of objects called pragma this and pragma that.
It's perhaps not clear why they are all needed.

For example `pragma` is included as a keyword in `ast_source.rs`. However it is implemented as a token in the lexer, not as a keyword. But the code that processes the ungrammar wants a keyword. There is certainly a way to avoid this by hacking it in. There is probably an easier way, using the current tools for converting the ungrammar file. But that will wait for later.

Closes #139 