### PR TITLE
Fairly large refactoring of parsing assignment statements.

### DIFF
--- a/crates/oq3_parser/src/grammar/params.rs
+++ b/crates/oq3_parser/src/grammar/params.rs
@@ -240,7 +240,7 @@ pub(crate) fn arg_gate_call_qubit(p: &mut Parser<'_>, m: Marker) -> bool {
     let mcomp = m.complete(p, IDENTIFIER);
     if p.at(T!['[']) {
         //        expressions::index_expr(p, mcomp);
-        expressions::indexed_identifer(p, mcomp);
+        expressions::indexed_identifier(p, mcomp);
         return true;
     }
     true

--- a/crates/oq3_semantics/src/syntax_to_semantics.rs
+++ b/crates/oq3_semantics/src/syntax_to_semantics.rs
@@ -409,7 +409,6 @@ fn from_expr_stmt(expr_stmt: synast::ExprStmt, context: &mut Context) -> Option<
         Some(GateCallExpr(gate_call)) => {
             from_gate_call_expr(gate_call, Vec::<asg::GateModifier>::new(), context)
         }
-
         Some(ModifiedGateCallExpr(mod_gate_call)) => {
             let modifiers = mod_gate_call
                 .modifiers()
@@ -838,7 +837,7 @@ fn from_assignment_stmt(
     assignment_stmt: &synast::AssignmentStmt,
     context: &mut Context,
 ) -> Option<asg::Stmt> {
-    let nameb = assignment_stmt.name(); // LHS of assignment
+    let nameb = assignment_stmt.identifier(); // LHS of assignment
     if nameb.is_some() {
         let name = nameb.as_ref().unwrap();
         let name_str = name.string();

--- a/crates/oq3_semantics/tests/from_string_tests.rs
+++ b/crates/oq3_semantics/tests/from_string_tests.rs
@@ -126,10 +126,7 @@ while (false) {
 x = 2;
 "##;
     let (program, errors, _symbol_table) = parse_string(code);
-    assert!(matches!(
-        &errors[0].kind(),
-        SemanticErrorKind::UndefVarError
-    ));
+    assert!(errors.len() > 0 && matches!(&errors[0].kind(), SemanticErrorKind::UndefVarError));
     assert_eq!(errors.len(), 1);
     assert_eq!(program.len(), 2);
 }

--- a/crates/oq3_syntax/src/ast/node_ext.rs
+++ b/crates/oq3_syntax/src/ast/node_ext.rs
@@ -98,6 +98,12 @@ fn text_of_first_token(node: &SyntaxNode) -> TokenText<'_> {
 //     }
 // }
 
+impl ast::AssignmentStmt {
+    pub fn identifier(&self) -> Option<ast::Identifier> {
+        support::child(&self.syntax)
+    }
+}
+
 impl ast::HasLoopBody for ast::ForStmt {
     fn loop_body(&self) -> Option<ast::BlockExpr> {
         let mut exprs = support::children(self.syntax());


### PR DESCRIPTION
Previously, assignment statements were parsed in three separate places.  Now they are parsed in one place. Some additional syntax error messages have been added.

Assignment statements are first parsed in the code that parses binary expressions at the top level in a statement. Most binary expressions are then wrapped in `EXPR_STMT`.  But assignments are filtered and are not wrapped. If an assignment is found in a non-top-level postion a syntax error is logged.

`fn stmt` tries `expr_stmt` last, which is where we parse assignment statements.  We could also try to parse an assignment earlier in `fn stmt`.  In this case, we would have to abandon if it turns out not to be an assignment. This might cause performance degredation, but I'm not at all sure.

If we keep going this route, we should probably organize `=`, `+=`, etc as variants in an enum, similarly to how binary ops are handled. There is a fair amount of machinery for binary ops. We might have to reproduce some of it.

Quite a bit of cruft was also removed. One r-a feature that we had carried around but not used is now being used: `Restrictions` in expressions.rs.