### PR TITLE
Implement casting to scalar end to end

### DIFF
--- a/crates/oq3_parser/src/grammar/expressions.rs
+++ b/crates/oq3_parser/src/grammar/expressions.rs
@@ -354,16 +354,6 @@ fn call_expr(p: &mut Parser<'_>, lhs: CompletedMarker) -> CompletedMarker {
     m.complete(p, CALL_EXPR)
 }
 
-// FIXME. Do we need to worry about precedence here, as in call_expr ?
-pub(crate) fn cast_expr(p: &mut Parser<'_>) -> CompletedMarker {
-    let m = p.start();
-    type_spec(p);
-    p.expect(T!['(']);
-    expr(p);
-    p.expect(T![')']);
-    m.complete(p, CAST_EXPRESSION)
-}
-
 fn type_name(p: &mut Parser<'_>) {
     if !p.current().is_type_name() {
         p.error("Expected name of type");
@@ -404,44 +394,6 @@ pub(crate) fn var_name(p: &mut Parser<'_>) {
     let m = p.start();
     p.expect(IDENT); // The declared identifier, ie variable name
     m.complete(p, NAME);
-}
-
-pub(crate) fn _returns_bool_classical_declaration_stmt(p: &mut Parser<'_>, m: Marker) -> bool {
-    p.eat(T![const]); // FIXME. Fix this in ungram and then move this to type_spec
-    let mstmt = p.start();
-    type_spec(p);
-    if p.current() == T!['('] {
-        p.expect(T!['(']);
-        expr(p);
-        p.expect(T![')']);
-        m.complete(p, CAST_EXPRESSION);
-        if p.at(SEMICOLON) {
-            p.expect(SEMICOLON);
-            mstmt.complete(p, EXPR_STMT);
-        } else {
-            mstmt.abandon(p);
-        }
-        return true;
-    } else {
-        mstmt.abandon(p);
-    }
-    var_name(p);
-    if p.eat(T![;]) {
-        m.complete(p, CLASSICAL_DECLARATION_STATEMENT);
-        return true;
-    }
-    if !p.expect(T![=]) {
-        m.abandon(p);
-        return false;
-    }
-    expr(p);
-    p.expect(T![;]); // why did I suddenly have to include this?
-    m.complete(p, CLASSICAL_DECLARATION_STATEMENT);
-    true
-}
-
-pub(crate) fn classical_declaration_stmt(p: &mut Parser<'_>, m: Marker) {
-    _returns_bool_classical_declaration_stmt(p, m);
 }
 
 // This includes a previously parsed expression as the first argument of `INDEX_EXPR`.

--- a/crates/oq3_parser/src/grammar/expressions/atom.rs
+++ b/crates/oq3_parser/src/grammar/expressions/atom.rs
@@ -63,9 +63,10 @@ pub(super) fn atom_expr(
         return Some((m, BlockLike::NotBlock));
     }
     let la = p.nth(1);
-    // Do we need to check la == T!['('] ?
+    // Do we need to check `la == T!['(']` ?
+    // If the type spec has a width (designator), then `la` will not be `(` in any case.
     if p.current().is_classical_type() {
-        let m = expressions::cast_expr(p);
+        let m = cast_expr(p);
         return Some((m, BlockLike::NotBlock));
     }
     let done = match p.current() {
@@ -95,6 +96,17 @@ pub(super) fn atom_expr(
         BlockLike::NotBlock
     };
     Some((done, blocklike))
+}
+
+// Note: `CAST_EXPR` also parsed in `classical_declaration_stmt` in items.rs
+// FIXME. Do we need to worry about precedence here, as in call_expr ?
+pub(crate) fn cast_expr(p: &mut Parser<'_>) -> CompletedMarker {
+    let m = p.start();
+    type_spec(p);
+    p.expect(T!['(']);
+    expr(p);
+    p.expect(T![')']);
+    m.complete(p, CAST_EXPRESSION)
 }
 
 fn gphase_call_expr(p: &mut Parser<'_>) -> CompletedMarker {

--- a/crates/oq3_semantics/src/syntax_to_semantics.rs
+++ b/crates/oq3_semantics/src/syntax_to_semantics.rs
@@ -561,6 +561,12 @@ fn from_expr(expr_maybe: Option<synast::Expr>, context: &mut Context) -> Option<
             Some(asg::ReturnExpression::new(expr_asg).to_texpr())
         }
 
+        synast::Expr::CastExpression(cast) => {
+            let typ = from_scalar_type(&cast.scalar_type().unwrap(), true, context);
+            let expr = from_expr(cast.expr(), context);
+            Some(asg::Cast::new(expr.unwrap(), typ).to_texpr())
+        }
+
         // Everything else is not yet implemented
         _ => {
             println!("Expression not supported {:?}", expr);

--- a/crates/oq3_semantics/tests/from_string_tests.rs
+++ b/crates/oq3_semantics/tests/from_string_tests.rs
@@ -551,3 +551,15 @@ int x = 3;
     assert_eq!(program.len(), 3);
     assert!(matches!(&program[1], asg::Stmt::SwitchCaseStmt(_)));
 }
+
+#[test]
+fn test_from_string_cast_width() {
+    let code = r##"
+float x;
+int[32](x);
+"##;
+    let (program, errors, _symbol_table) = parse_string(code);
+    assert_eq!(errors.len(), 0);
+    assert_eq!(program.len(), 2);
+    assert!(matches!(&program[1], asg::Stmt::ExprStmt(_)));
+}


### PR DESCRIPTION
* Casting to array types does not work. In fact array types are not supported at all in the parser.
* fixes a bug in the existing code to parse cast expressions to the AST.
* Rework and finish `Cast` in the ASG
* Implement AST -> AST for casting to scalar types

Closes #153