### PR TITLE
Implement alias: `let` statement

### DIFF
--- a/crates/oq3_parser/src/grammar/items.rs
+++ b/crates/oq3_parser/src/grammar/items.rs
@@ -98,6 +98,7 @@ pub(super) fn opt_item(p: &mut Parser<'_>, m: Marker) -> Result<(), Marker> {
         T![OPENQASM] => version_string(p, m),
         T![include] => include(p, m),
         T![switch] => switch_case_stmt(p, m),
+        T![let] => alias_stmt(p, m),
         _ => return Err(m),
     }
     Ok(())
@@ -409,4 +410,15 @@ fn barrier_(p: &mut Parser<'_>, m: Marker) {
     }
     p.expect(SEMICOLON);
     m.complete(p, BARRIER);
+}
+
+// alias or `let` statement
+fn alias_stmt(p: &mut Parser<'_>, m: Marker) {
+    assert!(p.at(T![let]));
+    p.bump_any(); // we know it is `let`.
+    name_r(p, ITEM_RECOVERY_SET);
+    p.expect(T![=]);
+    expressions::expr(p);
+    p.expect(SEMICOLON);
+    m.complete(p, ALIAS_DECLARATION_STATEMENT);
 }

--- a/crates/oq3_semantics/examples/semdemo.rs
+++ b/crates/oq3_semantics/examples/semdemo.rs
@@ -92,22 +92,28 @@ fn main() {
         #[allow(clippy::dbg_macro)]
         Some(Commands::Semantic { file_name }) => {
             let result = syntax_to_semantics::parse_source_file(file_name, None::<&[PathBuf]>);
-            let have_errors = result.any_errors();
-            if have_errors {
-                println!("Found errors: {}", have_errors);
+            if result.any_errors() {
+                println!("Found errors:");
                 result.print_errors();
+            } else {
+                println!("No errors found.");
             }
+            println!("{} statements in program:", result.program().len());
             result.program().print_asg_debug();
             dbg!(oq3_semantics::validate::count_symbol_errors(
                 result.program(),
                 result.symbol_table()
             ));
-            //            dbg!(semantics::validate::count_symbol_errors(&result.program().stmts, &result.symbol_table()));
         }
 
         Some(Commands::SemanticPretty { file_name }) => {
             let result = syntax_to_semantics::parse_source_file(file_name, None::<&[PathBuf]>);
-            println!("Found errors: {}", result.any_errors());
+            if result.any_errors() {
+                println!("Found errors:");
+                result.print_errors();
+            } else {
+                println!("No errors found.");
+            }
             result.print_errors();
             result.program().print_asg_debug_pretty();
         }

--- a/crates/oq3_semantics/src/types.rs
+++ b/crates/oq3_semantics/src/types.rs
@@ -73,6 +73,7 @@ pub enum Type {
     // Other
     Gate(i32, i32), // (num classical args, num quantum args)
     Range,          // temporary placeholder, perhaps
+    Set,
     Void,
     ToDo, // not yet implemented
     // Undefined means a type that is erroneously non-existent. This is not the same as unknown.

--- a/crates/oq3_semantics/tests/from_string_tests.rs
+++ b/crates/oq3_semantics/tests/from_string_tests.rs
@@ -563,3 +563,15 @@ int[32](x);
     assert_eq!(program.len(), 2);
     assert!(matches!(&program[1], asg::Stmt::ExprStmt(_)));
 }
+
+#[test]
+fn test_from_string_alias_stmt() {
+    let code = r##"
+qubit[10] q;
+let r = q[0:3] ++ q[5:9];
+"##;
+    let (program, errors, _symbol_table) = parse_string(code);
+    assert_eq!(errors.len(), 0);
+    assert_eq!(program.len(), 2);
+    assert!(matches!(&program[1], asg::Stmt::Alias(_)));
+}


### PR DESCRIPTION
* Implement alias in the parser through AST -> AST. Include a test.

* Put SetExpression, RangeExpression in the expression tree in asg.rs.  That is, wrap them as variants of `enum Expr`.  Trying to enforce semantics (and syntax) via the type system is a very interesting idea. There might even be a way to do it consistently without introducing a ton of complexity. But excluding only sets and ranges is arbitrary, and ad hoc. For example hardware qubits are in the expression tree. But they are syntactially illegal in many places. At the moment, putting these in the expression tree greatly reduces the complexity of the nest of structures.

* Comment out ArraySlice and other cruft in asg.rs that is unused.

* Make a couple of minor, desireable changes, perhaps improvmements, to semdemo.rs. eg Print number of statements found.

Closes #120