### PR TITLE
Support duration type in classical declaration statements

### DIFF
--- a/crates/oq3_semantics/src/syntax_to_semantics.rs
+++ b/crates/oq3_semantics/src/syntax_to_semantics.rs
@@ -846,6 +846,7 @@ fn from_scalar_type(
             None => Type::Bit(isconst.into()),
         },
         synast::ScalarTypeKind::Bool => Type::Bool(isconst.into()),
+        synast::ScalarTypeKind::Duration => Type::Duration(isconst.into()),
         _ => todo!(),
     }
 }

--- a/crates/oq3_semantics/tests/from_string_tests.rs
+++ b/crates/oq3_semantics/tests/from_string_tests.rs
@@ -575,3 +575,24 @@ let r = q[0:3] ++ q[5:9];
     assert_eq!(program.len(), 2);
     assert!(matches!(&program[1], asg::Stmt::Alias(_)));
 }
+
+#[test]
+fn test_from_string_duration_decl() {
+    let code = r##"
+duration x = 100 ns;
+"##;
+    let (program, errors, _symbol_table) = parse_string(code);
+    assert_eq!(errors.len(), 0);
+    assert_eq!(program.len(), 1);
+    let stmt = &program[0];
+    let decl = match stmt {
+        asg::Stmt::DeclareClassical(decl) => decl,
+        _ => unreachable!(),
+    };
+    let tlit = match decl.initializer().unwrap().expression() {
+        asg::Expr::Literal(asg::Literal::TimingIntLiteral(x)) => x,
+        _ => unreachable!(),
+    };
+    assert_eq!(*tlit.value(), 100);
+    assert_eq!(tlit.time_unit(), &asg::TimeUnit::NanoSecond);
+}

--- a/crates/oq3_syntax/src/ast/type_ext.rs
+++ b/crates/oq3_syntax/src/ast/type_ext.rs
@@ -21,15 +21,16 @@ impl ast::ScalarType {
     pub fn kind(&self) -> ScalarTypeKind {
         use ScalarTypeKind::*;
         match self.token().kind() {
-            T![int] => ScalarTypeKind::Int,
-            T![uint] => ScalarTypeKind::UInt,
-            T![float] => ScalarTypeKind::Float,
-            T![bit] => ScalarTypeKind::Bit,
-            T![bool] => ScalarTypeKind::Bool,
-            T![angle] => ScalarTypeKind::Angle,
-            T![stretch] => Stretch,
+            T![angle] => Angle,
+            T![bit] => Bit,
+            T![bool] => Bool,
             T![complex] => Complex,
-            _ => ScalarTypeKind::None, // record an error ?
+            T![duration] => Duration,
+            T![float] => Float,
+            T![int] => Int,
+            T![stretch] => Stretch,
+            T![uint] => UInt,
+            _ => None, // record an error ?
         }
     }
 


### PR DESCRIPTION
For example
```qasm
duration x = 100 ns;
```

There is no associated issue.