### PR TITLE
Put `Box` in enums rather than structs in variants in asg.rs

### DIFF
--- a/crates/oq3_semantics/src/types.rs
+++ b/crates/oq3_semantics/src/types.rs
@@ -232,6 +232,8 @@ pub fn promote_types(ty1: &Type, ty2: &Type) -> Type {
         (UInt(..), UInt(..)) => UInt(promote_width(ty1, ty2), isconst),
         (Int(..), Float(..)) => ty2.clone(),
         (Float(..), Int(..)) => ty1.clone(),
+        (UInt(..), Float(..)) => ty2.clone(),
+        (Float(..), UInt(..)) => ty1.clone(),
         _ => Void,
     }
 }


### PR DESCRIPTION
There are at least three reasons to do this:
1. It's one way to do it. It is uniform and implementing it looks the same in every case. 
2. It does not complicate getters as does putting `Box` in the structs.
3. Boxing in the structs requires in some cases more than one Box. Doing it in the `enum` always requires just one. That is, there is less indirection.

Closes #167