### PR TITLE
Improve implicit casting. Fix various kinds of tech debt.

### DIFF
--- a/crates/oq3_parser/src/grammar/expressions.rs
+++ b/crates/oq3_parser/src/grammar/expressions.rs
@@ -400,6 +400,22 @@ pub(crate) fn quantum_type_spec(p: &mut Parser<'_>) -> bool {
 pub(crate) fn designator(p: &mut Parser<'_>) -> bool {
     let m = p.start();
     p.eat(T!['[']);
+    // Log error for a literal designator that is not integer.  We are
+    // conservative here.  I am not sure that an expression that begins with one
+    // of the following literals cannot have an integer type. I am pretty sure
+    // this is the case, though. At some point we can review this and catch more
+    // syntax errors here.
+    //
+    // We assume here that it is not allowed to cast types to integer, even
+    // those that would be allowed in, say, arguments to function calls. I don't
+    // see this addressed in the spec.
+    if matches!(
+        p.current(),
+        FLOAT_NUMBER | SIMPLE_FLOAT_NUMBER | BYTE | CHAR | STRING | BIT_STRING
+    ) && matches!(p.nth(1), T![']'])
+    {
+        p.error("Literal type designator must be an integer.")
+    }
     expr(p);
     p.expect(T![']']);
     m.complete(p, DESIGNATOR);

--- a/crates/oq3_parser/src/grammar/expressions/atom.rs
+++ b/crates/oq3_parser/src/grammar/expressions/atom.rs
@@ -6,16 +6,18 @@ use super::*;
 pub(crate) const PATH_FIRST: TokenSet = TokenSet::new(&[IDENT, HARDWAREIDENT, T![:], T![<]]);
 
 pub(crate) const LITERAL_FIRST: TokenSet = TokenSet::new(&[
-    T![true],
-    T![false],
-    INT_NUMBER,
-    FLOAT_NUMBER,
-    SIMPLE_FLOAT_NUMBER,
-    TIMING_INT_NUMBER,
+    BIT_STRING,
     BYTE,
     CHAR,
+    FLOAT_NUMBER,
+    INT_NUMBER,
+    SIMPLE_FLOAT_NUMBER,
     STRING,
-    BIT_STRING,
+    // FIXME, remove the following two. They are no longer used.
+    TIMING_FLOAT_NUMBER,
+    TIMING_INT_NUMBER,
+    T![true],
+    T![false],
 ]);
 
 const TIMING_LITERAL_FIRST: TokenSet = TokenSet::new(&[INT_NUMBER, FLOAT_NUMBER]);

--- a/crates/oq3_semantics/src/types.rs
+++ b/crates/oq3_semantics/src/types.rs
@@ -220,7 +220,7 @@ fn promote_width(ty1: &Type, ty2: &Type) -> Width {
     }
 }
 
-// promotion suitable for some binary operations, eg +, -, *, /
+// promotion suitable for some binary operations, eg +, -, *
 pub fn promote_types(ty1: &Type, ty2: &Type) -> Type {
     use Type::*;
     if ty1 == ty2 {
@@ -228,8 +228,11 @@ pub fn promote_types(ty1: &Type, ty2: &Type) -> Type {
     }
     let isconst = promote_constness(ty1, ty2);
     match (ty1, ty2) {
+        // pairs without float
         (Int(..), Int(..)) => Int(promote_width(ty1, ty2), isconst),
         (UInt(..), UInt(..)) => UInt(promote_width(ty1, ty2), isconst),
+
+        // pairs with float
         (Int(..), Float(..)) => ty2.clone(),
         (Float(..), Int(..)) => ty1.clone(),
         (UInt(..), Float(..)) => ty2.clone(),

--- a/crates/oq3_syntax/src/ast/expr_ext.rs
+++ b/crates/oq3_syntax/src/ast/expr_ext.rs
@@ -287,16 +287,16 @@ impl ast::ArrayExpr {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum LiteralKind {
-    String(ast::String),
     BitString(ast::BitString),
-    IntNumber(ast::IntNumber),
+    Bool(bool),
+    Byte(ast::Byte),
+    Char(ast::Char),
     FloatNumber(ast::FloatNumber),
+    IntNumber(ast::IntNumber),
     SimpleFloatNumber(ast::SimpleFloatNumber),
+    String(ast::String),
     TimingFloatNumber(ast::TimingFloatNumber),
     TimingIntNumber(ast::TimingIntNumber),
-    Char(ast::Char),
-    Byte(ast::Byte),
-    Bool(bool),
 }
 
 // Literal strings in OQ3 occur only in a few contexts.

--- a/crates/oq3_syntax/src/ast/type_ext.rs
+++ b/crates/oq3_syntax/src/ast/type_ext.rs
@@ -5,16 +5,16 @@ use crate::{ast, SyntaxToken, T};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum ScalarTypeKind {
+    Angle,
     Bit,
     Bool,
-    Int,
-    UInt,
-    Float,
-    Angle,
-    Duration,
-    Stretch,
     Complex,
+    Duration,
+    Float,
+    Int,
     None, // For testing. Remove this
+    Stretch,
+    UInt,
 }
 
 impl ast::ScalarType {


### PR DESCRIPTION
* Improve implicit casting. For example, among arithmetic ops, handle division more correctly.

* Explicitize default match arm in many match expressions. Include more informative panic messages. This includes new messages for match arms that should not appear. We can perhaps do more to remove the need for such match arms.

* Log error if operands to binary op are quantum.

* Log syntax error for literal designators that are not integers. We let `true` and `false` pass though because I am not sure whether they are allowed to be cast. We do *not* allow BYTE and BITSTRING. Perhaps these can be implicitly cast in fact.

* Improve several comments.

* Finish translating scalar types from AST -> types::Type.

* Alphabetize some lists and follow this order when they appear in match arms, etc.