### PR TITLE
Remove obsolete function for parsing measure expression

### DIFF
--- a/crates/oq3_parser/src/grammar/expressions/atom.rs
+++ b/crates/oq3_parser/src/grammar/expressions/atom.rs
@@ -340,23 +340,13 @@ pub(crate) fn block_expr(p: &mut Parser<'_>) -> CompletedMarker {
     m.complete(p, BLOCK_EXPR)
 }
 
-// FIXME: This idiom for handling "measure" does not occur
-// in the original r-a crates. Need to refactor to avoid
-// starting a new Marker.
-// test return_expr
-// fn foo() {
-//     return;
-//     return 92;
-// }
 fn return_expr(p: &mut Parser<'_>) -> CompletedMarker {
     assert!(p.at(T![return]));
     let m = p.start();
-    p.bump(T![return]);
+    p.bump_any(); // return
+                  // parse possible returned expression
     if p.at_ts(EXPR_FIRST) {
         expr(p);
-    } else if p.at(T![measure]) {
-        let m1 = p.start();
-        expressions::items::measure_(p, m1);
     }
     m.complete(p, RETURN_EXPR)
 }

--- a/crates/oq3_parser/src/grammar/items.rs
+++ b/crates/oq3_parser/src/grammar/items.rs
@@ -212,25 +212,6 @@ fn reset_stmt(p: &mut Parser<'_>, m: Marker) {
     m.complete(p, RESET);
 }
 
-// FIXME: this has underscore, so should be private.
-// We should be able to refactor to keep this private.
-pub(crate) fn measure_(p: &mut Parser<'_>, m: Marker) {
-    p.bump(T![measure]);
-    match p.current() {
-        IDENT | HARDWAREIDENT => {
-            let m1 = p.start();
-            params::arg_gate_call_qubit(p, m1);
-        }
-        _ => {
-            p.error("expecting qubit(s) to measure");
-            m.abandon(p);
-            return;
-        }
-    }
-    p.expect(T![;]);
-    m.complete(p, MEASURE);
-}
-
 fn break_(p: &mut Parser<'_>, m: Marker) {
     p.bump(T![break]);
     p.expect(SEMICOLON);


### PR DESCRIPTION
There was a special case for `return measure q`. The code was unreachable, although the compiler did not detect it.