### PR TITLE
Record better error message on declaration of hardware qubit

### DIFF
--- a/crates/oq3_parser/src/grammar/items.rs
+++ b/crates/oq3_parser/src/grammar/items.rs
@@ -189,7 +189,12 @@ fn for_stmt(p: &mut Parser<'_>, m: Marker) {
 fn qubit_declaration_stmt(p: &mut Parser<'_>, m: Marker) {
     assert!(p.at(T![qubit]));
     expressions::qubit_type_spec(p);
-    expressions::var_name(p);
+    if p.at(HARDWAREIDENT) {
+        p.bump_any();
+        p.error("Declaring a hardware qubit is not allowed.");
+    } else {
+        expressions::var_name(p);
+    }
     p.expect(SEMICOLON);
     m.complete(p, QUANTUM_DECLARATION_STATEMENT);
 }


### PR DESCRIPTION
`qubit $1;` is illegal.
@atilag pointed out that the error message was confusing.

This PR introduces
1. a better error message.
2. better error recovery.

This is justified because this is an error that one expects will occur due to user intent, especially since allowing/requiring hardware qubits to be declared has been discussed.
