### PR TITLE
Support declaring single hardware qubits

### DIFF
--- a/crates/oq3_parser/src/grammar/expressions.rs
+++ b/crates/oq3_parser/src/grammar/expressions.rs
@@ -419,6 +419,9 @@ pub(crate) fn qubit_type_spec(p: &mut Parser<'_>) -> bool {
     type_name(p);
     if p.at(T!['[']) {
         designator(p);
+        if p.at(HARDWAREIDENT) {
+            p.error("Found designator in hardware qubit declaration.");
+        }
     }
     m.complete(p, QUBIT_TYPE);
     true

--- a/crates/oq3_parser/src/grammar/items.rs
+++ b/crates/oq3_parser/src/grammar/items.rs
@@ -189,9 +189,10 @@ fn for_stmt(p: &mut Parser<'_>, m: Marker) {
 fn qubit_declaration_stmt(p: &mut Parser<'_>, m: Marker) {
     assert!(p.at(T![qubit]));
     expressions::qubit_type_spec(p);
+    // Declaring hardware qubits is forbidden in the OQ3 spec.
+    // But it is used by all the current users of openqasm3_parser.
     if p.at(HARDWAREIDENT) {
-        p.bump_any();
-        p.error("Declaring a hardware qubit is not allowed.");
+        expressions::atom::hardware_qubit(p);
     } else {
         expressions::var_name(p);
     }

--- a/crates/oq3_semantics/src/asg.rs
+++ b/crates/oq3_semantics/src/asg.rs
@@ -176,6 +176,7 @@ pub enum Stmt {
     Continue,
     DeclareClassical(Box<DeclareClassical>),
     DeclareQuantum(DeclareQuantum),
+    DeclareHardwareQubit(DeclareHardwareQubit),
     Def,    // stub
     DefCal, // stub
     Delay(DelayStmt),
@@ -492,6 +493,29 @@ impl DeclareQuantum {
 
     pub fn name(&self) -> &SymbolIdResult {
         &self.name
+    }
+
+    pub fn to_stmt(self) -> Stmt {
+        Stmt::DeclareQuantum(self)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct DeclareHardwareQubit {
+    name: HardwareQubit,
+}
+
+impl DeclareHardwareQubit {
+    pub fn new(name: HardwareQubit) -> DeclareHardwareQubit {
+        DeclareHardwareQubit { name }
+    }
+
+    pub fn name(&self) -> &HardwareQubit {
+        &self.name
+    }
+
+    pub fn to_stmt(self) -> Stmt {
+        Stmt::DeclareHardwareQubit(self)
     }
 }
 

--- a/crates/oq3_syntax/openqasm3.ungram
+++ b/crates/oq3_syntax/openqasm3.ungram
@@ -423,7 +423,7 @@ OldStyleDeclarationStatement =
     ('creg' | 'qreg') Name Designator? ';'
 
 QuantumDeclarationStatement =
-   QubitType Name ';'
+   QubitType (Name | HardwareQubit) ';'
 
 AssignmentStmt =
     (Name | IndexedIdentifier) '=' rhs:Expr ';'

--- a/crates/oq3_syntax/src/ast/generated/nodes.rs
+++ b/crates/oq3_syntax/src/ast/generated/nodes.rs
@@ -400,6 +400,9 @@ impl QuantumDeclarationStatement {
     pub fn qubit_type(&self) -> Option<QubitType> {
         support::child(&self.syntax)
     }
+    pub fn hardware_qubit(&self) -> Option<HardwareQubit> {
+        support::child(&self.syntax)
+    }
     pub fn semicolon_token(&self) -> Option<SyntaxToken> {
         support::token(&self.syntax, T![;])
     }


### PR DESCRIPTION
Statements like `qubit $1;` are supported.

This commit also undoes the previous commit (last commit before tagging 0.3.0) that improved the error handling for attemted declaration of hardware qubits.

API CHANGE: new variant in asg::Stmt
The variant is  `Stmt::DeclareHardwareQubit(DeclareHardwareQubit)`

Declaring hardware qubits is not in the OQ3 spec. But all of our current users encounter (or write) qasm code with HW qubit declarations.

The struct `DeclareHardwareQubit` has method `name` to retrieve an instance of `asg::HardwareQubit`. Note that `asg::HardwareQubit` is not new in this commit.