### PR TITLE
Never run parser if there are lexer errors

### DIFF
--- a/crates/oq3_lexer/src/lib.rs
+++ b/crates/oq3_lexer/src/lib.rs
@@ -330,6 +330,7 @@ impl Cursor<'_> {
                         }
                     }
                 }
+                // Only `#pragma` and `#dim` may begin with a pound character
                 InvalidIdent
             }
 

--- a/crates/oq3_parser/src/lexed_str.rs
+++ b/crates/oq3_parser/src/lexed_str.rs
@@ -105,6 +105,10 @@ impl<'a> LexedStr<'a> {
             .map(|it| (it.token as usize, it.msg.as_str()))
     }
 
+    pub fn errors_len(&self) -> usize {
+        self.error.len()
+    }
+
     fn push(&mut self, kind: SyntaxKind, offset: usize) {
         self.kind.push(kind);
         self.start.push(offset as u32);
@@ -233,7 +237,7 @@ fn inner_extend_token<'a>(
             }
 
             oq3_lexer::TokenKind::InvalidIdent => {
-                err = "Ident contains invalid characters";
+                err = "Identifier contains invalid characters";
                 IDENT
             }
 

--- a/crates/oq3_semantics/examples/semdemo.rs
+++ b/crates/oq3_semantics/examples/semdemo.rs
@@ -120,18 +120,22 @@ fn main() {
 
         Some(Commands::Parse { file_name }) => {
             let parsed_source = oq3_source_file::parse_source_file(file_name, None::<&[PathBuf]>);
-            let parse_tree = parsed_source.syntax_ast().tree();
-            println!(
-                "Found {} stmts",
-                parse_tree.statements().collect::<Vec<_>>().len()
-            );
-            let syntax_errors = parsed_source.syntax_ast().errors();
+            let ast = parsed_source.syntax_ast();
+            let num_stmts = if ast.have_parse() {
+                ast.tree().statements().count()
+            } else {
+                0
+            };
+            println!("Found {num_stmts} stmts");
+            let syntax_errors = ast.errors();
             println!(
                 "Found {} parse errors:\n{:?}\n",
                 syntax_errors.len(),
                 syntax_errors
             );
-            print_tree(parse_tree);
+            if ast.have_parse() {
+                print_tree(ast.tree());
+            }
         }
 
         Some(Commands::ParseGreen { file_name }) => {

--- a/crates/oq3_semantics/src/syntax_to_semantics.rs
+++ b/crates/oq3_semantics/src/syntax_to_semantics.rs
@@ -96,7 +96,7 @@ where
     T: AsRef<str>,
     P: AsRef<Path>,
 {
-    let parsed_source =
+    let parsed_source: SourceString =
         oq3_source_file::parse_source_string(source, fake_file_path, search_path_list);
     analyze_source(parsed_source)
 }
@@ -110,7 +110,7 @@ where
     T: AsRef<Path>,
     P: AsRef<Path>,
 {
-    let parsed_source = oq3_source_file::parse_source_file(file_path, search_path_list);
+    let parsed_source: SourceFile = oq3_source_file::parse_source_file(file_path, search_path_list);
     analyze_source(parsed_source)
 }
 

--- a/crates/oq3_syntax/src/ast/make.rs
+++ b/crates/oq3_syntax/src/ast/make.rs
@@ -24,9 +24,7 @@ use crate::{ast, AstNode, SourceFile, SyntaxKind, SyntaxToken}; // utils::is_raw
 /// module defines shortcuts for common things.
 ///
 /// It's named `ext` rather than `shortcuts` just to keep it short.
-pub mod ext {
-    // GJL. This is intended to be used for semantic analysis, I think.
-}
+pub mod ext {}
 
 pub fn expr_loop(block: ast::BlockExpr) -> ast::Expr {
     expr_from_text(&format!("loop {block}"))


### PR DESCRIPTION
The OQ3 parser does
 lexer -> parser (to ast) -> semantic analysis

We want to impose a couple of invariants that were not in place in the r-a code:
1. If there are any lexing errors, parsing is not performed
2. If there are any parsing (to ast) errors, then semantic analysis is not performed.

This commit implements item number 1.


We follow r-a in pushing lexing and parsing errors onto a single vector. However, because
of rule 1, the errors in this vector will be either all lexer errors or all parser
errors. The semantic analysis code receives a structure representing a parsed file
(actually a structure including parsed included files) and errors. If there are any
errors, semantic analysis is aborted. At the level of the semantic analysis, there is no
need to check whether the errors returned are from lexing or parsing (and therefore
whether there is any parse tree at all).

The immediate impetus for this PR is that pragma statements in which "#pragma" is
misspelled are processed as tokens `InvalidIdent` and a lexing error is recorded.
Previously, lexing and parsing errors were lumped together and parsing always
proceeded. This would result in spurious parser errors added to the lexer error. Rather
than changing the parser (to ast) to recover from lexer errors, we don't allow the parser
to see lexer errors. If the parser detects a lexer error, it should throw an error.