### PR TITLE
Give correct type to qubit register param in `def`

### DIFF
--- a/crates/oq3_semantics/src/syntax_to_semantics.rs
+++ b/crates/oq3_semantics/src/syntax_to_semantics.rs
@@ -931,7 +931,13 @@ fn from_scalar_type(
         synast::ScalarTypeKind::None => panic!("You have found a bug in oq3_parser"),
         synast::ScalarTypeKind::Stretch => Type::Stretch(isconst.into()),
         synast::ScalarTypeKind::UInt => Type::UInt(width, isconst.into()),
-        synast::ScalarTypeKind::Qubit => Type::Qubit,
+        // The spec says a qubit register is equivalent to a 1D qubit array.
+        // Trying to maintain a non-existent distinction would lead to bad confusion.
+        // This is the point where we eliminate the distinction. (Code is repeated elsewhere.)
+        synast::ScalarTypeKind::Qubit => match width {
+            Some(width) => Type::QubitArray(ArrayDims::D1(width as usize)),
+            None => Type::Qubit,
+        },
     }
 }
 

--- a/crates/oq3_semantics/tests/from_string_tests.rs
+++ b/crates/oq3_semantics/tests/from_string_tests.rs
@@ -661,6 +661,6 @@ def xcheck(qubit[4] d, qubit a) -> bit {
 }
 "##;
     let (program, errors, _symbol_table) = parse_string(code);
-    assert_eq!(errors.len(), 1);
+    assert_eq!(errors.len(), 0);
     assert_eq!(program.len(), 2);
 }


### PR DESCRIPTION
Previously the type of any quantum parameter in a `def` was `Qubit`. This commit gives a qubit register the correct type, that is a one-dimensional qubit array.

A test was in place that verified the wrong behavior. Now it verifies the correct behavior.

Unrelated changes made while debugging: Some default match arms were changed to be explicit.

Closes #183