### PR TITLE
Create symbols for gates in standard library

### DIFF
--- a/crates/oq3_semantics/src/semantic_error.rs
+++ b/crates/oq3_semantics/src/semantic_error.rs
@@ -16,7 +16,7 @@ use crate::TextRange;
 pub enum SemanticErrorKind {
     UndefVarError,
     UndefGateError,
-    RedeclarationError,
+    RedeclarationError(String),
     ConstIntegerError, // need a better way to organize this kind of type error
     IncompatibleTypesError,
     MutateConstError,

--- a/crates/oq3_semantics/tests/from_string_tests.rs
+++ b/crates/oq3_semantics/tests/from_string_tests.rs
@@ -664,3 +664,26 @@ def xcheck(qubit[4] d, qubit a) -> bit {
     assert_eq!(errors.len(), 0);
     assert_eq!(program.len(), 2);
 }
+
+#[test]
+fn test_from_string_stdgates() {
+    let code = r##"
+include "stdgates.qasm";
+qubit q;
+h q;
+"##;
+    let (program, errors, _symbol_table) = parse_string(code);
+    assert_eq!(errors.len(), 0);
+    assert_eq!(program.len(), 2);
+}
+
+#[test]
+fn test_from_string_stdgates_2() {
+    let code = r##"
+gate h q {}
+include "stdgates.qasm";
+"##;
+    let (program, errors, _symbol_table) = parse_string(code);
+    assert_eq!(errors.len(), 1);
+    assert_eq!(program.len(), 1);
+}

--- a/crates/oq3_source_file/src/source_file.rs
+++ b/crates/oq3_source_file/src/source_file.rs
@@ -169,7 +169,12 @@ pub(crate) fn parse_included_files<P: AsRef<Path>>(
             synast::Stmt::Include(include) => {
                 let file: synast::FilePath = include.file().unwrap();
                 let file_path = file.to_string().unwrap();
-                Some(parse_source_file(file_path, search_path_list))
+                // stdgates.qasm will be handled "as if" it really existed.
+                if file_path == "stdgates.qasm" {
+                    None
+                } else {
+                    Some(parse_source_file(file_path, search_path_list))
+                }
             }
             _ => None,
         })


### PR DESCRIPTION
This commit implements the following.  Upon encountering `include "stdgates.qasm"` symbols are created for gates in the standard library according to the spec. No corresponding file need exist. None is actually read or included. If there is such a file in the include path, it is ignored.

Symbols carry a name and a type. The type `Gate` is parameterized by number of qubits and number of classical parameters. So the symbols created contain all the information that a declaration (but not definition) of the gate would carry. At the level of this parser/analyzer, this allows the gates to be used (called) after the include statement and allows type-checking to ensure that they are called with valid parameters (The latter is only partly implemented at the time of this commit.)

If a name in the standard library is already bound, then a semantic error is recorded. Since no real file is actually included, the location associated with the error is that of the `include` statement.