### PR TITLE
Use everywhere stdgates.inc rather than stdgates.qasm

### DIFF
--- a/crates/oq3_semantics/src/context.rs
+++ b/crates/oq3_semantics/src/context.rs
@@ -46,7 +46,7 @@ impl Context {
     // `SymbolTable::standard_library_gates()` returns a vector of
     // all names that were already bound. We record a redeclaration error
     // for each of these. The caller of the present method should pass
-    // the node corresponding to `include "stdgates.qasm"`. This is the
+    // the node corresponding to `include "stdgates.inc"`. This is the
     // best we can do since no real file has been included.
     /// Define gates in the standard library.
     pub fn standard_library_gates<T>(&mut self, node: &T)

--- a/crates/oq3_semantics/src/symbols.rs
+++ b/crates/oq3_semantics/src/symbols.rs
@@ -222,7 +222,7 @@ pub struct SymbolTable {
 }
 
 impl SymbolTable {
-    // This will be called if `include "stdgates.qasm"` is encountered. At present we don't have any include guard.
+    // This will be called if `include "stdgates.inc"` is encountered. At present we don't have any include guard.
     // FIXME: This function allocates a vector. The caller iterates over the vector.
     //  Would be nice to return the `FlatMap` instead. I tried doing this, but it was super compilcated.
     //  The compiler helps with which trait to use as the return type. But then tons of bugs occur within

--- a/crates/oq3_semantics/src/syntax_to_semantics.rs
+++ b/crates/oq3_semantics/src/syntax_to_semantics.rs
@@ -154,7 +154,7 @@ pub fn syntax_to_semantic<T: SourceTrait>(
             synast::Stmt::Include(include) => {
                 let file: synast::FilePath = include.file().unwrap();
                 let file_path = file.to_string().unwrap();
-                if file_path == "stdgates.qasm" {
+                if file_path == "stdgates.inc" {
                     // We do not use a file for standard library, but rather create the symbols.
                     context.standard_library_gates(&include);
                 } else {

--- a/crates/oq3_semantics/tests/from_string_tests.rs
+++ b/crates/oq3_semantics/tests/from_string_tests.rs
@@ -668,7 +668,7 @@ def xcheck(qubit[4] d, qubit a) -> bit {
 #[test]
 fn test_from_string_stdgates() {
     let code = r##"
-include "stdgates.qasm";
+include "stdgates.inc";
 qubit q;
 h q;
 "##;
@@ -681,7 +681,7 @@ h q;
 fn test_from_string_stdgates_2() {
     let code = r##"
 gate h q {}
-include "stdgates.qasm";
+include "stdgates.inc";
 "##;
     let (program, errors, _symbol_table) = parse_string(code);
     assert_eq!(errors.len(), 1);

--- a/crates/oq3_source_file/src/source_file.rs
+++ b/crates/oq3_source_file/src/source_file.rs
@@ -169,8 +169,8 @@ pub(crate) fn parse_included_files<P: AsRef<Path>>(
             synast::Stmt::Include(include) => {
                 let file: synast::FilePath = include.file().unwrap();
                 let file_path = file.to_string().unwrap();
-                // stdgates.qasm will be handled "as if" it really existed.
-                if file_path == "stdgates.qasm" {
+                // stdgates.inc will be handled "as if" it really existed.
+                if file_path == "stdgates.inc" {
                     None
                 } else {
                     Some(parse_source_file(file_path, search_path_list))

--- a/crates/oq3_syntax/examples/itemparse.rs
+++ b/crates/oq3_syntax/examples/itemparse.rs
@@ -12,7 +12,7 @@ int q;
 
 OPENQASM 3.1;
 
-include "stdgates.qasm";
+include "stdgates.inc";
 
 defcalgrammar "openpulse";
 


### PR DESCRIPTION
There was some confusion. In particular the previous commit used the incorrect name.