### PR TITLE
Check types of LHS and RHS in assignment "to identifier"

### DIFF
--- a/crates/oq3_semantics/src/asg.rs
+++ b/crates/oq3_semantics/src/asg.rs
@@ -932,7 +932,7 @@ impl IntLiteral {
     }
 
     pub fn to_texpr(self) -> TExpr {
-        TExpr::new(self.to_expr(), Type::UInt(Some(128), IsConst::True))
+        TExpr::new(self.to_expr(), Type::Int(Some(128), IsConst::True))
     }
 }
 

--- a/crates/oq3_semantics/src/semantic_error.rs
+++ b/crates/oq3_semantics/src/semantic_error.rs
@@ -19,6 +19,8 @@ pub enum SemanticErrorKind {
     RedeclarationError(String),
     ConstIntegerError, // need a better way to organize this kind of type error
     IncompatibleTypesError,
+    IncompatibleDimensionError,
+    CastError,
     MutateConstError,
     IncludeNotInGlobalScopeError,
     ReturnInGlobalScopeError,

--- a/crates/oq3_semantics/tests/ast_tests.rs
+++ b/crates/oq3_semantics/tests/ast_tests.rs
@@ -31,7 +31,7 @@ fn test_texpr_int_literal() {
     let literal = IntLiteral::new(1_u32, true);
     let texpr = literal.clone().to_texpr();
     assert_eq!(texpr.expression(), &literal.to_expr());
-    assert_eq!(texpr.get_type(), &Type::UInt(Some(128), IsConst::True));
+    assert_eq!(texpr.get_type(), &Type::Int(Some(128), IsConst::True));
 }
 
 //

--- a/crates/oq3_semantics/tests/from_string_tests.rs
+++ b/crates/oq3_semantics/tests/from_string_tests.rs
@@ -687,3 +687,107 @@ include "stdgates.inc";
     assert_eq!(errors.len(), 1);
     assert_eq!(program.len(), 1);
 }
+
+#[test]
+fn test_from_string_check_assign_types_1() {
+    let code = r##"
+bit[3] b;
+qubit[2] q;
+b = measure q;
+"##;
+    let (program, errors, _symbol_table) = parse_string(code);
+    assert_eq!(errors.len(), 1);
+    assert!(matches!(
+        &errors[0].kind(),
+        SemanticErrorKind::IncompatibleDimensionError
+    ));
+    assert_eq!(program.len(), 3);
+}
+
+#[test]
+fn test_from_string_check_assign_types_2() {
+    let code = r##"
+float b;
+qubit[2] q;
+b = measure q;
+"##;
+    let (program, errors, _symbol_table) = parse_string(code);
+    assert_eq!(errors.len(), 1);
+    assert!(matches!(
+        &errors[0].kind(),
+        SemanticErrorKind::IncompatibleTypesError
+    ));
+    assert_eq!(program.len(), 3);
+}
+
+// Bug
+#[test]
+fn test_from_string_check_assign_types_3() {
+    let code = r##"
+float b[2];
+qubit[2] q;
+b[1] = measure q;
+"##;
+    let (_program, errors, _symbol_table) = parse_string(code);
+    assert_eq!(errors.len(), 0);
+}
+
+#[test]
+fn test_from_string_check_assign_types_4() {
+    let code = r##"
+float x0;
+x0 = 1;
+"##;
+    let (_program, errors, _symbol_table) = parse_string(code);
+    assert_eq!(errors.len(), 0);
+}
+
+#[test]
+fn test_from_string_check_assign_types_5() {
+    let code = r##"
+uint x0;
+x0 = 1;
+"##;
+    let (_program, errors, _symbol_table) = parse_string(code);
+    assert_eq!(errors.len(), 0);
+}
+
+#[test]
+fn test_from_string_check_assign_types_6() {
+    let code = r##"
+uint x0;
+x0 = -1;
+"##;
+    let (_program, errors, _symbol_table) = parse_string(code);
+    assert_eq!(errors.len(), 1);
+    assert!(matches!(&errors[0].kind(), SemanticErrorKind::CastError));
+}
+
+#[test]
+fn test_from_string_check_assign_types_7() {
+    let code = r##"
+int x0;
+x0 = 2.0;
+"##;
+    let (_program, errors, _symbol_table) = parse_string(code);
+    assert_eq!(errors.len(), 1);
+    assert!(matches!(
+        &errors[0].kind(),
+        SemanticErrorKind::IncompatibleTypesError
+    ));
+}
+
+#[test]
+fn test_from_string_check_assign_types_8() {
+    let code = r##"
+float xx = 3;
+int yy;
+yy = xx;
+"##;
+    let (_program, errors, _symbol_table) = parse_string(code);
+    assert_eq!(errors.len(), 1);
+    assert!(matches!(
+        &errors[0].kind(),
+        SemanticErrorKind::IncompatibleTypesError
+    ));
+}


### PR DESCRIPTION
Before there was no checking that the types of the LHS and RHS were valid in assignment, with the exception of checking constness.

This commit introduces some checking in the case that the LHS is represented by an identifier (i.e. not an indexed identifier) Checking if the LHS is an indexed identifier, for example `b[1] = measure q;` remains to be implemented.

* If types have same base array type, but dimensions differ, an `IncompatibleDimensionError` is recorded. This is tested, for example, with
```
bit[3] b;
qubit[2] q;
b = measure q;
```

* If the RHS is an integer literal and the LHS is unsigned, then the sign of the literal is examined and the RHS is wrapped in `Cast` if the sign is positive. Otherwise `CastError`.

* If the type of the RHS can be cast to that of the left, the RHS is wrapped in `Cast`.

* Otherwise `IncompatibleTypes` is recorded.

Several tests of these new behaviors are included.

A few details of things added:

* Fix erroneous `Type` of integer literal. Before we had UInt even though in the data we stored the sign of the literal. The type is now `Int`.
* Introduce semantic errors: `IncompatibleDimensionError` and `CastError`. The latter is for trying to cast a negative integer literal to an unsigned type. We could perhaps to do better. Perhaps just make this an `IncompatibleTypes` error instead.