### PR TITLE
Various small changes while preparing to improve type checking

### DIFF
--- a/crates/oq3_semantics/src/asg.rs
+++ b/crates/oq3_semantics/src/asg.rs
@@ -341,6 +341,15 @@ pub enum IndexOperator {
     ExpressionList(ExpressionList),
 }
 
+impl IndexOperator {
+    pub fn num_dims(&self) -> usize {
+        match self {
+            IndexOperator::SetExpression(_) => 1,
+            IndexOperator::ExpressionList(elist) => elist.len(),
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExpressionList {
     pub expressions: Vec<TExpr>,
@@ -371,6 +380,14 @@ impl HardwareQubit {
 impl ExpressionList {
     pub fn new(expressions: Vec<TExpr>) -> ExpressionList {
         ExpressionList { expressions }
+    }
+
+    pub fn len(&self) -> usize {
+        self.expressions.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.expressions.is_empty()
     }
 }
 

--- a/crates/oq3_semantics/src/semantic_error.rs
+++ b/crates/oq3_semantics/src/semantic_error.rs
@@ -20,6 +20,7 @@ pub enum SemanticErrorKind {
     ConstIntegerError, // need a better way to organize this kind of type error
     IncompatibleTypesError,
     IncompatibleDimensionError,
+    TooManyIndexes,
     CastError,
     MutateConstError,
     IncludeNotInGlobalScopeError,

--- a/crates/oq3_semantics/src/types.rs
+++ b/crates/oq3_semantics/src/types.rs
@@ -92,7 +92,7 @@ pub enum ArrayDims {
 }
 
 impl ArrayDims {
-    pub fn num_dims(&self) -> i32 {
+    pub fn num_dims(&self) -> usize {
         match self {
             ArrayDims::D1(..) => 1,
             ArrayDims::D2(..) => 2,
@@ -180,12 +180,23 @@ impl Type {
     pub fn dims(&self) -> Option<Vec<usize>> {
         use Type::*;
         match self {
-            QubitArray(dims) | IntArray(dims) => Some(dims.dims()),
+            QubitArray(dims) | IntArray(dims) | BitArray(dims, _) => Some(dims.dims()),
             _ => None,
         }
     }
 
-    pub fn equal_up_to_dims(&self, other: &Type) -> bool {
+    pub fn num_dims(&self) -> usize {
+        use Type::*;
+        match self {
+            QubitArray(dims) | IntArray(dims) | BitArray(dims, _) => dims.num_dims(),
+            _ => 0,
+        }
+    }
+
+    // FIXME: Not finished
+    /// Return `true` if the types have the same base type.
+    /// The number of dimensions and dimensions may differ.
+    pub fn equal_up_to_shape(&self, other: &Type) -> bool {
         use Type::*;
         if self == other {
             return true;
@@ -193,7 +204,23 @@ impl Type {
         if matches!(self, BitArray(_, _)) && matches!(other, BitArray(_, _)) {
             return true;
         }
+        if matches!(self, QubitArray(_)) && matches!(other, QubitArray(_)) {
+            return true;
+        }
         false
+    }
+
+    // FIXME: Not finished
+    /// Return `true` if the types have the same base type and the same shape.
+    /// The dimensions of each axis may differ.
+    pub fn equal_up_to_dims(&self, other: &Type) -> bool {
+        if self == other {
+            return true;
+        }
+        if self.num_dims() != other.num_dims() {
+            return false;
+        }
+        self.equal_up_to_shape(other)
     }
 }
 


### PR DESCRIPTION
* Remove an unecessary `clone` and add comment
* Add some methods for asg::IndexOperator
* Rename some functions for consistency.
* Corrections in comments.
* Make some improvements in methods in types.rs Some of these methods are not completed yet. But this brings it a bit closer.
* Add `equal_up_to_shape`. Try to make this and `equal_up_to_dims` do the correct things