### PR TITLE
Modify the parser to make importing to Qiskit easier or possible

### DIFF
--- a/crates/oq3_semantics/src/asg.rs
+++ b/crates/oq3_semantics/src/asg.rs
@@ -186,7 +186,7 @@ pub enum Stmt {
     ForStmt(ForStmt),
     GPhaseCall(GPhaseCall),
     GateCall(GateCall), // A statement because a gate call does not return anything
-    GateDeclaration(GateDeclaration),
+    GateDefinition(GateDefinition),
     InputDeclaration(InputDeclaration),
     OutputDeclaration(OutputDeclaration),
     If(If),
@@ -576,21 +576,21 @@ impl Block {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct GateDeclaration {
+pub struct GateDefinition {
     name: SymbolIdResult,
     params: Option<Vec<SymbolIdResult>>,
     qubits: Vec<SymbolIdResult>,
     block: Block,
 }
 
-impl GateDeclaration {
+impl GateDefinition {
     pub fn new(
         name: SymbolIdResult,
         params: Option<Vec<SymbolIdResult>>,
         qubits: Vec<SymbolIdResult>,
         block: Block,
-    ) -> GateDeclaration {
-        GateDeclaration {
+    ) -> GateDefinition {
+        GateDefinition {
             name,
             params,
             qubits,
@@ -599,7 +599,7 @@ impl GateDeclaration {
     }
 
     pub fn to_stmt(self) -> Stmt {
-        Stmt::GateDeclaration(self)
+        Stmt::GateDefinition(self)
     }
 
     pub fn name(&self) -> &SymbolIdResult {
@@ -608,6 +608,10 @@ impl GateDeclaration {
 
     pub fn params(&self) -> Option<&[SymbolIdResult]> {
         self.params.as_deref()
+    }
+
+    pub fn num_params(&self) -> usize {
+        self.params.as_ref().map_or(0, Vec::len)
     }
 
     pub fn qubits(&self) -> &[SymbolIdResult] {

--- a/crates/oq3_semantics/src/asg.rs
+++ b/crates/oq3_semantics/src/asg.rs
@@ -120,7 +120,7 @@ pub enum Expr {
     UnaryExpr(Box<UnaryExpr>),
     Literal(Literal),
     Cast(Box<Cast>),
-    Identifier(Identifier),
+    Identifier(SymbolIdResult),
     HardwareQubit(HardwareQubit),
     IndexExpression(Box<IndexExpression>),
     IndexedIdentifier(IndexedIdentifier),
@@ -747,7 +747,7 @@ pub enum GateModifier {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum GateOperand {
-    Identifier(Identifier),
+    Identifier(SymbolIdResult),
     HardwareQubit(HardwareQubit),
     IndexedIdentifier(IndexedIdentifier),
 }
@@ -1273,49 +1273,6 @@ impl BinaryExpr {
                 BinaryExpr::new(op, left, right).to_texpr(Type::ToDo)
             }
         }
-    }
-}
-
-// FIXME: Elsewhere, we use `name` for a SymbolIdResult. The actual string can be looked up
-// from the SymbolId. But here we use `name` for the string. This is not uniform
-// and potentially confusing. I think we will have to ditch the approach below.
-// The name of the identifer is stored in both `name` and as a field in `symbol_id`.
-// But this is only true if `symbol_id` is not Err. In case of a semantic error,
-// the symbol_id may not be resolved, which we represent by a value of `Err(SymbolError)`.
-// This happens when attempting to look up the binding of an identifier that is in
-// fact not bound in any visible scope.
-// We carry the name in `name` as well in order to facilitate diagnosing the semantic
-// error. But we have not concrete plan for this. So the field `name` below may be removed.
-// And in that case, the variant `Ident(Ident)` in `enum Expr` above could be replaced with
-// `Ident(SymbolId)`.
-#[derive(Clone, Debug, PartialEq)]
-pub struct Identifier {
-    name: String,
-    symbol: SymbolIdResult,
-}
-
-impl Identifier {
-    pub fn new<T: ToString>(name: T, symbol: SymbolIdResult) -> Identifier {
-        Identifier {
-            name: name.to_string(),
-            symbol,
-        }
-    }
-
-    pub fn to_expr(self) -> Expr {
-        Expr::Identifier(self)
-    }
-
-    pub fn to_texpr(self, typ: Type) -> TExpr {
-        TExpr::new(self.to_expr(), typ)
-    }
-
-    pub fn name(&self) -> &str {
-        self.name.as_ref()
-    }
-
-    pub fn symbol(&self) -> &SymbolIdResult {
-        &self.symbol
     }
 }
 

--- a/crates/oq3_semantics/src/symbols.rs
+++ b/crates/oq3_semantics/src/symbols.rs
@@ -275,6 +275,20 @@ impl SymbolTable {
             })
             .collect()
     }
+
+    pub fn hardware_qubits(&self) -> Vec<(&str, SymbolId)> {
+        self.all_symbols
+            .iter()
+            .enumerate()
+            .filter_map(|(n, sym)| {
+                if let Type::HardwareQubit = &sym.symbol_type() {
+                    Some((sym.name(), SymbolId(n)))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
 }
 
 #[allow(dead_code)]

--- a/crates/oq3_semantics/src/symbols.rs
+++ b/crates/oq3_semantics/src/symbols.rs
@@ -259,6 +259,22 @@ impl SymbolTable {
             })
             .collect::<Vec<_>>()
     }
+
+    /// Return a Vec of information about all gate declarations. Each element
+    /// is a tuple of (gate name, symbol id, num classical params, num quantum params).
+    pub fn gates(&self) -> Vec<(&str, SymbolId, usize, usize)> {
+        self.all_symbols
+            .iter()
+            .enumerate()
+            .filter_map(|(n, sym)| {
+                if let Type::Gate(num_cl, num_qu) = &sym.symbol_type() {
+                    Some((sym.name(), SymbolId(n), *num_cl, *num_qu))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
 }
 
 #[allow(dead_code)]

--- a/crates/oq3_semantics/src/symbols.rs
+++ b/crates/oq3_semantics/src/symbols.rs
@@ -325,7 +325,7 @@ impl SymbolTable {
         self.symbol_table_stack.pop();
     }
 
-    /// If a binding for `name` exists in the current scope, return `None`.
+    /// If a binding for `name` exists in the current scope, return `Err(SymbolError::AlreadyBound)`.
     /// Otherwise, create a new Symbol from `name` and `typ`, bind `name` to
     /// this Symbol in the current scope, and return the Symbol.
     pub fn new_binding(&mut self, name: &str, typ: &Type) -> Result<SymbolId, SymbolError> {
@@ -386,7 +386,7 @@ impl SymbolTable {
 
     // FIXME: fix awkward scope numbering
     /// Look up `name` in the stack of symbol tables. Return `SymbolRecord`
-    /// if the symbol is found. Otherwise `None`.
+    /// if the symbol is found. Otherwise `Err(SymbolError::MissingBinding)`.
     pub fn lookup(&self, name: &str) -> Result<SymbolRecord, SymbolError> {
         for (scope_level_rev, table) in self.symbol_table_stack.iter().rev().enumerate() {
             if let Some(symbol_id) = table.get_symbol_id(name) {

--- a/crates/oq3_semantics/src/syntax_to_semantics.rs
+++ b/crates/oq3_semantics/src/syntax_to_semantics.rs
@@ -111,7 +111,10 @@ where
     P: AsRef<Path>,
 {
     let parsed_source: SourceFile = oq3_source_file::parse_source_file(file_path, search_path_list);
-    analyze_source(parsed_source)
+    let res = analyze_source(parsed_source);
+    let gs = &res.context.symbol_table().gates();
+    dbg!(gs);
+    res
 }
 
 fn analyze_source<T: SourceTrait>(parsed_source: T) -> ParseResult<T> {
@@ -362,7 +365,7 @@ fn from_stmt(stmt: synast::Stmt, context: &mut Context) -> Option<asg::Stmt> {
                 ),
                 &name_node,
             );
-            Some(asg::GateDeclaration::new(gate_name_symbol_id, params, qubits, block).to_stmt())
+            Some(asg::GateDefinition::new(gate_name_symbol_id, params, qubits, block).to_stmt())
         }
 
         synast::Stmt::Def(def_stmt) => {

--- a/crates/oq3_semantics/src/syntax_to_semantics.rs
+++ b/crates/oq3_semantics/src/syntax_to_semantics.rs
@@ -111,10 +111,7 @@ where
     P: AsRef<Path>,
 {
     let parsed_source: SourceFile = oq3_source_file::parse_source_file(file_path, search_path_list);
-    let res = analyze_source(parsed_source);
-//    let gs = &res.context.symbol_table().hardware_qubits();
-//    dbg!(gs);
-    res
+    analyze_source(parsed_source)
 }
 
 fn analyze_source<T: SourceTrait>(parsed_source: T) -> ParseResult<T> {

--- a/crates/oq3_semantics/src/syntax_to_semantics.rs
+++ b/crates/oq3_semantics/src/syntax_to_semantics.rs
@@ -357,8 +357,8 @@ fn from_stmt(stmt: synast::Stmt, context: &mut Context) -> Option<asg::Stmt> {
             let gate_name_symbol_id = context.new_binding(
                 name_node.string().as_ref(),
                 &Type::Gate(
-                    num_params.try_into().unwrap(),
-                    qubits.len().try_into().unwrap(),
+                    num_params,
+                    qubits.len(),
                 ),
                 &name_node,
             );
@@ -768,7 +768,7 @@ fn from_gate_call_expr(
             Type::Gate(np, nq) => (np, nq),
             _ => (0, 0),
         };
-        if def_num_params != num_params.try_into().unwrap() {
+        if def_num_params != num_params {
             if num_params != 0 {
                 // If num params is mismatched, locate error at list of params supplied.
                 context.insert_error(NumGateParamsError, &gate_call_expr.arg_list().unwrap());
@@ -778,7 +778,7 @@ fn from_gate_call_expr(
             }
         }
         let num_qubits: usize = gate_operands.len();
-        if def_num_qubits != num_qubits.try_into().unwrap() {
+        if def_num_qubits != num_qubits {
             if num_qubits == 0 {
                 // This probably can't happen because no qubit args is not recognized syntactially
                 // as a gate call.

--- a/crates/oq3_semantics/src/types.rs
+++ b/crates/oq3_semantics/src/types.rs
@@ -71,7 +71,7 @@ pub enum Type {
     DurationArray(ArrayDims),
 
     // Other
-    Gate(i32, i32), // (num classical args, num quantum args)
+    Gate(usize, usize), // (num classical args, num quantum args)
     Range,
     Set,
     Void,

--- a/crates/oq3_semantics/src/validate.rs
+++ b/crates/oq3_semantics/src/validate.rs
@@ -96,8 +96,8 @@ impl<T: SymTrait> WalkSymbols<T> for Stmt {
 
 impl<T: SymTrait> WalkSymbols<T> for Expr {
     fn walk_symbols(&self, context: &mut SymContext<T>) {
-        if let Expr::Identifier(ident) = self {
-            (context.func)(ident.symbol())
+        if let Expr::Identifier(sym) = self {
+            (context.func)(sym)
         }
     }
 }


### PR DESCRIPTION
The parser no longer is expected to parse bogus gate definitions
from stdgates.inc. Rather, symbols are entered as if it had been
parsed. This requires modifying how the Qiskit importer works.

The main change here is implementing `SymbolTable::gates`. This
returns some information on all gates found in the symbol table.
Included is the minimal information required for the Qiskit importer
to map `SymbolId`s to Qiskit gates.

* A smaller convenience:
  Add GateDeclaration::num_params() for convenience

Several other changes are noted in the git commit messages
* Simplifying `Expr::Identifier`
* Refactoring symbol lookup