### PR TITLE
Fix bug when initializing bit declaration with measurement

### DIFF
--- a/crates/oq3_semantics/src/syntax_to_semantics.rs
+++ b/crates/oq3_semantics/src/syntax_to_semantics.rs
@@ -1001,7 +1001,8 @@ fn from_classical_declaration_statement(
     // However, we would lose the information in `text_range` unless we do something to preserve it.
     let symbol_id = context.new_binding(name_str.as_ref(), &typ, type_decl);
     if let Some(ref initializer) = initializer {
-        if !types::can_cast_loose(&typ, initializer.get_type()) {
+        let init_typ = initializer.get_type();
+        if !(&typ == init_typ) && !types::can_cast_loose(&typ, init_typ) {
             context.insert_error(IncompatibleTypesError, type_decl);
         }
     }

--- a/crates/oq3_semantics/src/types.rs
+++ b/crates/oq3_semantics/src/types.rs
@@ -304,7 +304,7 @@ fn equal_up_to_constness(_ty1: &Type, _ty2: &Type) -> bool {
     //     }
 }
 
-// Return `true` of  `from_type` can be cast to `to_type`.
+// Return `true` if  `from_type` can be cast to `to_type`.
 // Warning: It is assumed that `equal_up_to_constness(from_type, to_type)`
 // returns `false`. If not, `can_cast_strict` may give incorrect results.
 // Unused at the moment

--- a/crates/oq3_semantics/tests/from_string_tests.rs
+++ b/crates/oq3_semantics/tests/from_string_tests.rs
@@ -842,3 +842,14 @@ fn test_from_string_imaginary_float_literal_1() {
         _ => unreachable!(),
     };
 }
+
+// Issue #200
+#[test]
+fn test_from_string_init_bit_with_measure() {
+    let code = r##"
+bit mid = measure $1;
+"##;
+    let (program, errors, _symbol_table) = parse_string(code);
+    assert_eq!(errors.len(), 0);
+    assert_eq!(program.len(), 1);
+}


### PR DESCRIPTION
This bug actually happens with any initializer of a bit from a bit type.

This commit fixes this bug. However the type checking in classical declaration statements is still broken in general.

Closes #200