### PR TITLE
Check types and do casting in classical declarations

### DIFF
--- a/crates/oq3_semantics/src/asg.rs
+++ b/crates/oq3_semantics/src/asg.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // The definition of the abstract semantic graph (ASG) as well as the API for using it.
-// Construction of this typed ASG from syntactic AST is in string_to_semantic.rs.
+// Construction of this typed ASG from syntactic AST is in syntax_to_semantics.rs
 
 // SymbolIdResult can represent a valid symbol symbol, via a symbol id, or a semantic error.
 // We need to insert SymbolIdResult everywhere a symbol is needed in the semantic tree.


### PR DESCRIPTION
Implement checking compatibility of types of lhs and rhs in classical assignment statement. If an implicit cast is needed, add an explicit cast.

Prior to this commit there was essentially nothing in place to do these things (just a very small amount, and broken at that). This is certainly not the end of the story. There will be edge cases. But this is a good start which should capture many common scenarios.

Since we are developing quickly and writing tests for this ASG is very tedious and verbose, we have not been testing very carefully. However, the kind of thing done in this commit is inherently fragile, so we need to begin with more testing.

Closes #203