### PR TITLE
Record error for statements in global scope where disallowed

### DIFF
--- a/crates/oq3_semantics/src/semantic_error.rs
+++ b/crates/oq3_semantics/src/semantic_error.rs
@@ -23,6 +23,7 @@ pub enum SemanticErrorKind {
     TooManyIndexes,
     CastError,
     MutateConstError,
+    NotInGlobalScopeError,
     IncludeNotInGlobalScopeError,
     ReturnInGlobalScopeError,
     NumGateParamsError,

--- a/crates/oq3_semantics/src/symbols.rs
+++ b/crates/oq3_semantics/src/symbols.rs
@@ -370,6 +370,10 @@ impl SymbolTable {
         self.current_scope().scope_type()
     }
 
+    pub(crate) fn in_global_scope(&self) -> bool {
+        self.current_scope_type() == ScopeType::Global
+    }
+
     // Return `true` if `name` is bound in current scope.
     fn current_scope_contains_name(&self, name: &str) -> bool {
         self.current_scope().contains_name(name)


### PR DESCRIPTION
Some statements are not allowed except in global scope. `def`, `qubit`, `gate` `array` declarations.

This commit records a semantic error in this case.