### PR TITLE
Improvements to `SymbolTable::gates` function

### DIFF
--- a/crates/oq3_semantics/src/symbols.rs
+++ b/crates/oq3_semantics/src/symbols.rs
@@ -249,26 +249,22 @@ impl SymbolTable {
             .collect::<Vec<_>>()
     }
 
-    /// Return a Vec of information about all gate declarations. Each element
+    /// Return an iterator giving information about all gate declarations. Each element
     /// is a tuple of (gate name, symbol id, num classical params, num quantum params).
     /// `gphase` is not included here. It is treated specially.
     /// `U` is also filtered out, as it is builtin.
-    pub fn gates(&self) -> Vec<(&str, SymbolId, usize, usize)> {
-        self.all_symbols
-            .iter()
-            .enumerate()
-            .filter_map(|(n, sym)| {
-                if let Type::Gate(num_cl, num_qu) = &sym.symbol_type() {
-                    if sym.name() == "U" {
-                        None
-                    } else {
-                        Some((sym.name(), SymbolId(n), *num_cl, *num_qu))
-                    }
-                } else {
+    pub fn gates(&self) -> impl Iterator<Item = (&str, SymbolId, usize, usize)> {
+        self.all_symbols.iter().enumerate().filter_map(|(n, sym)| {
+            if let Type::Gate(num_cl, num_qu) = &sym.symbol_type() {
+                if sym.name() == "U" {
                     None
+                } else {
+                    Some((sym.name(), SymbolId(n), *num_cl, *num_qu))
                 }
-            })
-            .collect()
+            } else {
+                None
+            }
+        })
     }
 
     /// Return a list of hardware qubits referenced in the program as a

--- a/crates/oq3_semantics/src/symbols.rs
+++ b/crates/oq3_semantics/src/symbols.rs
@@ -251,13 +251,19 @@ impl SymbolTable {
 
     /// Return a Vec of information about all gate declarations. Each element
     /// is a tuple of (gate name, symbol id, num classical params, num quantum params).
+    /// `gphase` is not included here. It is treated specially.
+    /// `U` is also filtered out, as it is builtin.
     pub fn gates(&self) -> Vec<(&str, SymbolId, usize, usize)> {
         self.all_symbols
             .iter()
             .enumerate()
             .filter_map(|(n, sym)| {
                 if let Type::Gate(num_cl, num_qu) = &sym.symbol_type() {
-                    Some((sym.name(), SymbolId(n), *num_cl, *num_qu))
+                    if sym.name() == "U" {
+                        None
+                    } else {
+                        Some((sym.name(), SymbolId(n), *num_cl, *num_qu))
+                    }
                 } else {
                     None
                 }


### PR DESCRIPTION
Use impl trait for `SymbolTable::gate` return type. Return an iterator. Before, we `collect`ed the output to a `Vec`.

Filter U gate from output of SymbolTable::gates
    
The Qiskit importer otherwise needs to filter this gate out.
Other consumers probably would do so as well. If it is useful in
another context, we can add an option to include the U gate
    
Review comment: https://github.com/Qiskit/qiskit/pull/12087#discussion_r1586950430