### PR TITLE
Fix broken pipe in run_tests_less.sh.

### DIFF
--- a/run_tests_less.sh
+++ b/run_tests_less.sh
@@ -9,4 +9,4 @@
 # are breaking the source. Or may break it.
 # r-a uses some system to control this that we have not, and may never, set up.
 
-cargo test --lib --tests --color always -- --skip sourcegen_ast --skip sourcegen_ast_nodes |& less -R
+cargo test --lib --tests --color always -- --skip sourcegen_ast --skip sourcegen_ast_nodes 2>&1 | less -R


### PR DESCRIPTION
Running the script (prior to this PR) results in: `./run_tests_less.sh: 12: Syntax error: "&" unexpected`.

This is because plain `sh` (Bourne shell) does not support the `bash` shorthand `|&` for `2>&1 |`.