### PR TITLE
Try to compile and pass lint with both 1.70 and 1.75

### DIFF
--- a/crates/oq3_syntax/Cargo.toml
+++ b/crates/oq3_syntax/Cargo.toml
@@ -25,7 +25,7 @@ rowan = "0.15.11"
 rustc-hash = "1.1.0"
 smol_str = "0.2.0"
 stdx = { version = "0.0.188", package = "ra_ap_stdx"}
-triomphe = { version = "0.1.8", default-features = false, features = ["std"] }
+triomphe = { version = "<= 0.1.11", default-features = false, features = ["std"] }
 xshell = "0.2.2"
 rustversion = "1.0"
 # local crates

--- a/crates/oq3_syntax/src/ptr.rs
+++ b/crates/oq3_syntax/src/ptr.rs
@@ -35,7 +35,7 @@ impl<N: AstNode> Clone for AstPtr<N> {
     #[rustversion::before(1.74)]
     fn clone(&self) -> AstPtr<N> {
         AstPtr {
-            raw: self.raw.clone(),
+            raw: self.raw,
             _ty: PhantomData,
         }
     }
@@ -82,7 +82,7 @@ impl<N: AstNode> AstPtr<N> {
 
     #[rustversion::before(1.74)]
     pub fn syntax_node_ptr(&self) -> SyntaxNodePtr {
-        self.raw.clone()
+        self.raw
     }
 
     pub fn text_range(&self) -> TextRange {


### PR DESCRIPTION
In CI this often fails even if it succeeds locally.

* Limit the version of triomphe to 0.1.11 because 0.1.12 uses unstable features
* Remove some conditional compilation for clippy complaints. Maybe clippy was upgraded independently of rustc?