### PR TITLE
Remove dependence on crate ra_ap_stdx

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-11, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
     steps:
     - uses: actions/checkout@v3
     - name: Rust Format
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-11, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
     steps:
     - uses: actions/checkout@v3
     - name: Install Rust toolchain

--- a/crates/oq3_semantics/Cargo.toml
+++ b/crates/oq3_semantics/Cargo.toml
@@ -18,7 +18,7 @@ doctest = false
 oq3_source_file.workspace = true
 oq3_syntax.workspace = true
 hashbrown = { version = "0.12.3" }
-rowan = "0.15.11"
+rowan = {version = "<=0.15.15"}
 boolenum = "0.1"
 
 [dev-dependencies]

--- a/crates/oq3_syntax/Cargo.toml
+++ b/crates/oq3_syntax/Cargo.toml
@@ -24,7 +24,6 @@ once_cell = "1.17.0"
 rowan = "0.15.11"
 rustc-hash = "1.1.0"
 smol_str = "0.2.0"
-stdx = { version = "0.0.188", package = "ra_ap_stdx"}
 triomphe = { version = "<= 0.1.11", default-features = false, features = ["std"] }
 xshell = "0.2.2"
 rustversion = "1.0"

--- a/crates/oq3_syntax/Cargo.toml
+++ b/crates/oq3_syntax/Cargo.toml
@@ -21,7 +21,7 @@ either = "1.7.0"
 indexmap = "2.0.0"
 itertools = "0.10.5"
 once_cell = "1.17.0"
-rowan = "0.15.11"
+rowan = {version = "<=0.15.15"}
 rustc-hash = "1.1.0"
 smol_str = "0.2.0"
 triomphe = { version = "<= 0.1.11", default-features = false, features = ["std"] }

--- a/crates/oq3_syntax/src/lib.rs
+++ b/crates/oq3_syntax/src/lib.rs
@@ -28,11 +28,6 @@
     semicolon_in_expressions_from_macros
 )]
 
-#[allow(unused)]
-macro_rules! eprintln {
-    ($($tt:tt)*) => { stdx::eprintln!($($tt)*) };
-}
-
 mod parsing;
 mod ptr;
 mod sourcegen;
@@ -48,7 +43,6 @@ pub mod ted;
 
 use std::marker::PhantomData;
 
-use stdx::format_to;
 use triomphe::Arc;
 
 pub use crate::{
@@ -451,4 +445,21 @@ fn api_walkthrough() {
         }
     }
     assert_eq!(exprs_cast, exprs_visit);
+}
+
+// #229
+// This macro is copied from ra_ap_stdx. It is the only feature
+// we needed from ra_ap_stdx. But that crate put us in a version bind.
+/// Appends formatted string to a `String`.
+#[macro_export]
+macro_rules! format_to {
+    ($buf:expr) => ();
+    ($buf:expr, $lit:literal $($arg:tt)*) => {
+        {
+            use ::std::fmt::Write as _;
+            // We can't do ::std::fmt::Write::write_fmt($buf, format_args!($lit $($arg)*))
+            // unfortunately, as that loses out on autoref behavior.
+            _ = $buf.write_fmt(format_args!($lit $($arg)*))
+        }
+    };
 }

--- a/crates/oq3_syntax/src/tests.rs
+++ b/crates/oq3_syntax/src/tests.rs
@@ -1,9 +1,7 @@
 // Copyright contributors to the openqasm-parser project
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(not(feature = "in-rust-tree"))]
 mod ast_src;
-#[cfg(not(feature = "in-rust-tree"))]
 mod sourcegen_ast;
 
 use crate::ast;


### PR DESCRIPTION
* Remove importing stdx::eprintln!. This was unused in any case
* Vendor a very small macro `format_to` from ra_ap_stdx. This was the last feature that we used from that library.
* Remove ra_ap_stdx from crates/oq3_syntax/Cargo.toml
* Remove a macro call testing whether we are in the rust tree. CI failed locally with this test. We are never in the rust tree, so it should be removed in any case.

Closes #229

* See https://github.com/Qiskit/qiskit/issues/13096