### PR TITLE
Bump version to 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 rust-version = "1.70"
 edition = "2021"
 license = "Apache-2.0"
@@ -15,8 +15,8 @@ repository = "https://github.com/Qiskit/openqasm3_parser"
 
 [workspace.dependencies]
 # local crates
-oq3_lexer = { path = "crates/oq3_lexer", version = "0.6.0" }
-oq3_parser = { path = "crates/oq3_parser", version = "0.6.0" }
-oq3_syntax = { path = "crates/oq3_syntax", version = "0.6.0" }
-oq3_semantics = { path = "crates/oq3_semantics", version = "0.6.0" }
-oq3_source_file = { path = "crates/oq3_source_file", version = "0.6.0" }
+oq3_lexer = { path = "crates/oq3_lexer", version = "0.7.0" }
+oq3_parser = { path = "crates/oq3_parser", version = "0.7.0" }
+oq3_syntax = { path = "crates/oq3_syntax", version = "0.7.0" }
+oq3_semantics = { path = "crates/oq3_semantics", version = "0.7.0" }
+oq3_source_file = { path = "crates/oq3_source_file", version = "0.7.0" }


### PR DESCRIPTION
The most important commit since 0.6.0 eliminates a dependency so that these crates will build with the most recent stable Rust version 1.81