### PR TITLE
Update dependency tree and raise MSRV to 1.79

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@1.70
+      uses: dtolnay/rust-toolchain@1.79
     - name: Build
       run: cargo build --release --verbose
     - name: Run tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 version = "0.7.0"
-rust-version = "1.70"
+rust-version = "1.79"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["OpenQASM3 parser team"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenQASM 3 Parser
 [![License](https://img.shields.io/github/license/Qiskit/rustworkx.svg?style=popout-square)](https://opensource.org/licenses/Apache-2.0)
-[![Minimum rustc 1.70](https://img.shields.io/badge/rustc-1.70+-blue.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
+[![Minimum rustc 1.79](https://img.shields.io/badge/rustc-1.79+-blue.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
 [![oq3_semantics crate](https://img.shields.io/crates/v/oq3_semantics.svg)](https://crates.io/crates/oq3_semantics)
 
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,4 +1,4 @@
 # This does not work for some reason.
 # filter-map-identitiy = false
 
-msrv = "1.70.0"
+msrv = "1.79.0"

--- a/crates/oq3_lexer/Cargo.toml
+++ b/crates/oq3_lexer/Cargo.toml
@@ -12,12 +12,12 @@ categories.workspace = true
 repository.workspace = true
 
 [dependencies]
-unicode-xid = "0.2.0"
+unicode-xid = "0.2.6"
 
 [dependencies.unicode-properties]
-version = "0.1.0"
+version = "0.1.3"
 default-features = false
 features = ["emoji"]
 
 [dev-dependencies]
-expect-test = "1.4.0"
+expect-test = "1.5.1"

--- a/crates/oq3_lexer/src/lib.rs
+++ b/crates/oq3_lexer/src/lib.rs
@@ -83,7 +83,7 @@ pub enum TokenKind {
     /// (allowed by default) lint, and are treated as regular identifier
     /// tokens.
     /// UnknownPrefix,
-
+    ///
     /// Examples: `1.0e-40`, `1000dt`, `1000ms`. Here `dt` and `ms` are suffixes.
     /// OpenQASM3 relevance? -> Note that `_` is an invalid
     /// suffix, but may be present here on string and float literals. Users of

--- a/crates/oq3_lexer/src/unescape.rs
+++ b/crates/oq3_lexer/src/unescape.rs
@@ -361,7 +361,7 @@ where
             _ => ascii_check(c, mode.characters_should_be_ascii()).map(Into::into),
         };
         let end = src.len() - chars.as_str().len();
-        callback(start..end, res.map(Into::into));
+        callback(start..end, res);
     }
 }
 

--- a/crates/oq3_parser/Cargo.toml
+++ b/crates/oq3_parser/Cargo.toml
@@ -17,7 +17,7 @@ doctest = false
 [dependencies]
 oq3_lexer.workspace = true
 drop_bomb = "0.1.5"
-limit = { version = "0.0.188", package = "ra_ap_limit" }
+limit = { version = "0.0.229", package = "ra_ap_limit" }
 
 [dev-dependencies]
-expect-test = "1.4.0"
+expect-test = "1.5.1"

--- a/crates/oq3_parser/src/input.rs
+++ b/crates/oq3_parser/src/input.rs
@@ -76,7 +76,7 @@ impl Input {
     // }
     pub(crate) fn is_joint(&self, n: usize) -> bool {
         let (idx, b_idx) = self.bit_index(n);
-        self.joint[idx] & 1 << b_idx != 0
+        self.joint[idx] & (1 << b_idx) != 0
     }
 }
 

--- a/crates/oq3_parser/src/output.rs
+++ b/crates/oq3_parser/src/output.rs
@@ -114,7 +114,7 @@ impl Output {
     }
 
     pub(crate) fn leave_node(&mut self) {
-        let e = (Self::EXIT_EVENT as u32) << Self::TAG_SHIFT | Self::EVENT_MASK;
+        let e = ((Self::EXIT_EVENT as u32) << Self::TAG_SHIFT) | Self::EVENT_MASK;
         self.event.push(e)
     }
 

--- a/crates/oq3_semantics/Cargo.toml
+++ b/crates/oq3_semantics/Cargo.toml
@@ -17,8 +17,8 @@ doctest = false
 [dependencies]
 oq3_source_file.workspace = true
 oq3_syntax.workspace = true
-hashbrown = { version = "0.12.3" }
-rowan = {version = "<=0.15.15"}
+hashbrown = { version = "0.15.2" }
+rowan = {version = "<=0.16.1"}
 boolenum = "0.1"
 
 [dev-dependencies]

--- a/crates/oq3_semantics/tests/from_string_tests.rs
+++ b/crates/oq3_semantics/tests/from_string_tests.rs
@@ -126,7 +126,7 @@ while (false) {
 x = 2;
 "##;
     let (program, errors, _symbol_table) = parse_string(code);
-    assert!(errors.len() > 0 && matches!(&errors[0].kind(), SemanticErrorKind::UndefVarError));
+    assert!(!errors.is_empty() && matches!(&errors[0].kind(), SemanticErrorKind::UndefVarError));
     assert_eq!(errors.len(), 1);
     assert_eq!(program.len(), 2);
 }

--- a/crates/oq3_source_file/Cargo.toml
+++ b/crates/oq3_source_file/Cargo.toml
@@ -15,5 +15,5 @@ repository.workspace = true
 doctest = false
 
 [dependencies]
-ariadne = { version = "0.3.0", features = ["auto-color"] }
+ariadne = { version = "0.5.0", features = ["auto-color"] }
 oq3_syntax.workspace = true

--- a/crates/oq3_source_file/src/api.rs
+++ b/crates/oq3_source_file/src/api.rs
@@ -76,9 +76,8 @@ pub fn report_error(message: &str, span: &Range<usize>, file_path: &str, source:
     let a = colors.next();
     // `offset` is a zero-indexed character offset from beginning of file.
     // Here `offset` is character index of start of error.
-    let offset = span.start;
-    Report::build(ReportKind::Error, file_path, offset)
-        //        .with_code(3)
+    Report::build(ReportKind::Error, (file_path, span.clone()))
+        .with_code(3)
         .with_message(message)
         .with_config(Config::default().with_compact(true))
         .with_label(

--- a/crates/oq3_source_file/src/api.rs
+++ b/crates/oq3_source_file/src/api.rs
@@ -74,8 +74,6 @@ pub fn report_error(message: &str, span: &Range<usize>, file_path: &str, source:
     let mut colors = ColorGenerator::new();
     // Generate & choose some colours for each of our elements
     let a = colors.next();
-    // `offset` is a zero-indexed character offset from beginning of file.
-    // Here `offset` is character index of start of error.
     Report::build(ReportKind::Error, (file_path, span.clone()))
         .with_code(3)
         .with_message(message)

--- a/crates/oq3_syntax/Cargo.toml
+++ b/crates/oq3_syntax/Cargo.toml
@@ -16,15 +16,15 @@ doctest = false
 
 [dependencies]
 # external crates
-cov-mark = "2.0.0-pre.1"
-either = "1.7.0"
-indexmap = "2.0.0"
-itertools = "0.10.5"
-once_cell = "1.17.0"
-rowan = {version = "<=0.15.15"}
-rustc-hash = "1.1.0"
-smol_str = "0.2.0"
-triomphe = { version = "<= 0.1.11", default-features = false, features = ["std"] }
+cov-mark = "2.0.0"
+either = "1.15.0"
+indexmap = "2.8.0"
+itertools = "0.14.0"
+once_cell = "1.21.0"
+rowan = {version = "<=0.16.1"}
+rustc-hash = "2.1.1"
+smol_str = "0.3.2"
+triomphe = { version = "<= 0.1.14", default-features = false, features = ["std"] }
 xshell = "0.2.2"
 rustversion = "1.0"
 # local crates

--- a/crates/oq3_syntax/examples/demoparse.rs
+++ b/crates/oq3_syntax/examples/demoparse.rs
@@ -97,9 +97,9 @@ fn main() {
 
 /// Construct the fqpn of an example from a filename.
 fn example_path(example: &str) -> PathBuf {
-    return ["crates", "oq3_syntax", "examples", "oq3_source", example]
+    ["crates", "oq3_syntax", "examples", "oq3_source", example]
         .iter()
-        .collect();
+        .collect()
 }
 
 fn read_example_source(file_name: &str) -> String {

--- a/crates/oq3_syntax/src/ast/token_ext.rs
+++ b/crates/oq3_syntax/src/ast/token_ext.rs
@@ -103,7 +103,8 @@ impl CommentKind {
 impl ast::Whitespace {
     pub fn spans_multiple_lines(&self) -> bool {
         let text = self.text();
-        text.find('\n').is_some_and(|idx| text[idx + 1..].contains('\n'))
+        text.find('\n')
+            .is_some_and(|idx| text[idx + 1..].contains('\n'))
     }
 }
 

--- a/crates/oq3_syntax/src/ast/token_ext.rs
+++ b/crates/oq3_syntax/src/ast/token_ext.rs
@@ -103,8 +103,7 @@ impl CommentKind {
 impl ast::Whitespace {
     pub fn spans_multiple_lines(&self) -> bool {
         let text = self.text();
-        text.find('\n')
-            .map_or(false, |idx| text[idx + 1..].contains('\n'))
+        text.find('\n').is_some_and(|idx| text[idx + 1..].contains('\n'))
     }
 }
 
@@ -246,7 +245,7 @@ impl ast::BitString {
     pub fn value(&self) -> Option<Cow<'_, str>> {
         let text = self.text();
         let text = &text[self.text_range_between_quotes()? - self.syntax().text_range().start()];
-        return Some(Cow::Borrowed(text));
+        Some(Cow::Borrowed(text))
     }
 
     // FIXME: find a good name for this function


### PR DESCRIPTION
This commit updates the dependency tree to pull in the latest versions of all the dependencies which were now out of date. The exception is dev dependencies aren't update and also ra_ap_limit is held to 0.0.229 because newer releases require rust >= 1.80.0 which is higher than Qiskit >2.0's MSRV of 1.79. Accordingly this commit updates the MSRV to 1.79 to make sure there aren't any compatibility issues with older versions of Rust.