### PR TITLE
Fix swapped logical not and bitwise not

### DIFF
--- a/crates/oq3_syntax/src/ast/expr_ext.rs
+++ b/crates/oq3_syntax/src/ast/expr_ext.rs
@@ -90,8 +90,8 @@ impl ast::Expr {
 impl ast::PrefixExpr {
     pub fn op_kind(&self) -> Option<UnaryOp> {
         let res = match self.op_token()?.kind() {
-            T![~] => UnaryOp::LogicNot,
-            T![!] => UnaryOp::Not,
+            T![!] => UnaryOp::LogicNot,
+            T![~] => UnaryOp::Not,
             T![-] => UnaryOp::Neg,
             _ => return None,
         };

--- a/crates/oq3_syntax/src/ast/operators.rs
+++ b/crates/oq3_syntax/src/ast/operators.rs
@@ -20,9 +20,9 @@ pub enum RangeOp {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum UnaryOp {
-    /// `~`
-    LogicNot,
     /// `!`
+    LogicNot,
+    /// `~`
     Not,
     /// `-`
     Neg,


### PR DESCRIPTION
`LogicNot` and `Not` were introduced with swapped meanings in  #92

This gives them the correct meanings.

I want to test this from oq3_semantics. But at present, neither of the two operators is supported at that level.

Closes #227