### PR TITLE
Implement some const value tracking/folding

### DIFF
--- a/crates/oq3_semantics/src/asg.rs
+++ b/crates/oq3_semantics/src/asg.rs
@@ -163,6 +163,35 @@ impl TExpr {
     }
 }
 
+#[derive(Debug)]
+pub struct TryFromU32Error(pub(crate) ());
+
+impl TryFrom<&TExpr> for u32 {
+    type Error = TryFromU32Error;
+    fn try_from(value: &TExpr) -> Result<Self, TryFromU32Error> {
+        match &value.expression {
+            Expr::Cast(thecast) => {
+                match **thecast {
+                    Cast {
+                        operand:
+                            TExpr {
+                                expression:
+                                    Expr::Literal(Literal::Int(IntLiteral {
+                                        value: int_value,
+                                        sign: true,
+                                    })),
+                                ty: _, // Type::Int(_, _),
+                            },
+                        typ: _, // Type::Int(_, _),
+                    } => u32::try_from(int_value).map_err(|_| TryFromU32Error(())),
+                    _ => Err(TryFromU32Error(())),
+                }
+            }
+            _ => Err(TryFromU32Error(())),
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum Stmt {
     Alias(Box<Alias>),

--- a/crates/oq3_semantics/src/context.rs
+++ b/crates/oq3_semantics/src/context.rs
@@ -4,8 +4,9 @@
 use crate::asg;
 use crate::semantic_error::SemanticErrorKind::*;
 use crate::semantic_error::{SemanticErrorKind, SemanticErrorList};
-use crate::symbols::{SymbolIdResult, SymbolRecordResult, SymbolTable};
+use crate::symbols::{SymbolId, SymbolIdResult, SymbolRecordResult, SymbolTable};
 use crate::types::Type;
+use hashbrown::HashMap;
 use oq3_syntax::ast::AstNode;
 use std::path::PathBuf;
 
@@ -21,6 +22,8 @@ pub struct Context {
     /// The symbol table built during analysis.
     pub symbol_table: SymbolTable,
 
+    pub const_values: HashMap<SymbolId, asg::TExpr>,
+
     /// Temporary storage for annoations. Annotations are pushed here as they are
     /// parsed. When the annotated function definition is parsed, the annotations are attached
     /// to the representation of the function definition.
@@ -33,6 +36,7 @@ impl Context {
             program: asg::Program::new(),
             semantic_errors: SemanticErrorList::new(file_path),
             symbol_table: SymbolTable::new(),
+            const_values: HashMap::<SymbolId, asg::TExpr>::new(),
             annotations: Vec::<asg::Annotation>::new(),
         }
     }
@@ -58,6 +62,19 @@ impl Context {
     pub fn symbol_table(&self) -> &SymbolTable {
         &self.symbol_table
     }
+
+    pub fn insert_const_value(&mut self, id: SymbolId, value: asg::TExpr) {
+        self.const_values.insert(id, value);
+    }
+
+    pub fn get_const_value(&self, id: SymbolId) -> Option<&asg::TExpr> {
+        self.const_values.get(&id)
+    }
+
+    // Unused
+    // pub fn const_value_len(&self) -> usize {
+    //     self.const_values.len()
+    // }
 
     // `SymbolTable::standard_library_gates()` returns a vector of
     // all names that were already bound. We record a redeclaration error

--- a/crates/oq3_semantics/src/semantic_error.rs
+++ b/crates/oq3_semantics/src/semantic_error.rs
@@ -35,6 +35,7 @@ pub enum SemanticErrorKind {
     PermissionDenied,
     IsADirectory,
     InvalidFilename,
+    InvalidDesignatorError,
     // Generic IO error. Any io::ErrorKind that we do not translated explicitly
     IOError,
 }

--- a/crates/oq3_semantics/tests/from_string_tests.rs
+++ b/crates/oq3_semantics/tests/from_string_tests.rs
@@ -1314,3 +1314,63 @@ uint a = -99;
     let (_program, errors, _symbol_table) = parse_string(code);
     assert_eq!(errors.len(), 1);
 }
+
+#[test]
+fn test_from_string_const_designator_1() {
+    let code = r##"
+const int n = 3;
+int[n] x;
+"##;
+    let (_program, errors, _symbol_table) = parse_string(code);
+    assert_eq!(errors.len(), 0);
+}
+
+#[test]
+fn test_from_string_const_designator_2() {
+    let code = r##"
+const int n = -3;
+int[n] x;
+"##;
+    let (_program, errors, _symbol_table) = parse_string(code);
+    assert_eq!(errors.len(), 1);
+}
+
+#[test]
+fn test_from_string_const_designator_3() {
+    let code = r##"
+const int SIZE = 4;
+qubit[SIZE] q2;  // Declare a 4-qubit register.
+"##;
+    let (_program, errors, _symbol_table) = parse_string(code);
+    assert_eq!(errors.len(), 0);
+}
+
+#[test]
+fn test_from_string_const_designator_4() {
+    let code = r##"
+const uint SIZE = 4;
+qubit[SIZE] q2;  // Declare a 4-qubit register.
+"##;
+    let (_program, errors, _symbol_table) = parse_string(code);
+    assert_eq!(errors.len(), 0);
+}
+
+#[test]
+fn test_from_string_const_designator_5() {
+    let code = r##"
+const uint n = 10;
+int[n] x;
+"##;
+    let (_program, errors, _symbol_table) = parse_string(code);
+    assert_eq!(errors.len(), 0);
+}
+
+#[test]
+fn test_from_string_const_designator_6() {
+    let code = r##"
+const float n = 3.0;
+int[n] x;
+"##;
+    let (_program, errors, _symbol_table) = parse_string(code);
+    assert_eq!(errors.len(), 1);
+}


### PR DESCRIPTION
* Add a table to Context to store values bound to `const` variables
* Support replacing a const variable with its value in a designator.
* Rename many functions to rationalize naming a bit.
* Refactoring in symbols.rs

There are many immediate improvements to be made. For example
* `const int x = 3;` currently binds an expression for the value of x that includes casting a very wide integer type. This system is borrowed vaguely from rust. In any case, it should be resolved to a Literal int, because that is the only way the RHS can enter into the program.