### PR TITLE
Add more support for #dim=n

### DIFF
--- a/crates/oq3_parser/src/grammar/expressions.rs
+++ b/crates/oq3_parser/src/grammar/expressions.rs
@@ -397,13 +397,29 @@ pub(crate) fn array_type_spec(p: &mut Parser<'_>) -> bool {
     type_spec(p);
     p.expect(COMMA);
     // Parse the dimensions.
-    loop {
-        expr(p);
+    if p.at(T![dim]) {
+        let m = p.start();
+        p.bump_any();
+        if p.eat(T![=]) {
+            expr(p);
+        } else {
+            p.error("Expecting '=' after #dim");
+        }
         if p.at(T![']']) {
             p.bump_any();
-            break;
+        } else {
+            p.error("Expecting ']' after #dim specification");
         }
-        p.expect(COMMA);
+        m.complete(p, DIM_EXPR);
+    } else {
+        loop {
+            expr(p);
+            if p.at(T![']']) {
+                p.bump_any();
+                break;
+            }
+            p.expect(COMMA);
+        }
     }
     m.complete(p, ARRAY_TYPE);
     true

--- a/crates/oq3_semantics/src/asg.rs
+++ b/crates/oq3_semantics/src/asg.rs
@@ -130,6 +130,7 @@ pub enum Expr {
     MeasureExpression(Box<MeasureExpression>),
     SetExpression(SetExpression),
     RangeExpression(Box<RangeExpression>),
+    NullExpr,
 }
 
 /// Typed expression implemented by tagging an `Expr` with a `Type`.

--- a/crates/oq3_semantics/src/semantic_error.rs
+++ b/crates/oq3_semantics/src/semantic_error.rs
@@ -38,6 +38,7 @@ pub enum SemanticErrorKind {
     InvalidDesignatorError,
     // Generic IO error. Any io::ErrorKind that we do not translated explicitly
     IOError,
+    NotImplementedError,
 }
 
 impl SemanticErrorKind {

--- a/crates/oq3_semantics/src/syntax_to_semantics.rs
+++ b/crates/oq3_semantics/src/syntax_to_semantics.rs
@@ -1171,14 +1171,16 @@ fn classical_declaration_statement_to_asg_stmt(
     type_decl: &synast::ClassicalDeclarationStatement,
     context: &mut Context,
 ) -> asg::Stmt {
-    if type_decl.array_type().is_some() {
+    let lhs_type = if type_decl.array_type().is_some() {
         if !context.symbol_table().in_global_scope() {
             context.insert_error(NotInGlobalScopeError, type_decl);
         }
-        panic!("Array types are not supported yet in the ASG");
-    }
-    let scalar_type = type_decl.scalar_type().unwrap();
-    let lhs_type = scalar_type_to_type(&scalar_type, type_decl.const_token().is_some(), context);
+        context.insert_error(NotImplementedError, type_decl);
+        Type::ToDo
+    } else {
+        let scalar_type = type_decl.scalar_type().unwrap();
+        scalar_type_to_type(&scalar_type, type_decl.const_token().is_some(), context)
+    };
     let name_str = type_decl.name().unwrap().string();
     let initializer = expr_to_asg_texpr(type_decl.expr(), context);
     let symbol_id = context.new_binding(name_str.as_ref(), &lhs_type, type_decl);

--- a/crates/pipeline-tests/tests/snapshots/runner__tests__snippets__reference__subroutine__array.qasm-parse.snap
+++ b/crates/pipeline-tests/tests/snapshots/runner__tests__snippets__reference__subroutine__array.qasm-parse.snap
@@ -7,7 +7,7 @@ expect-parse: Todo
 --- parser ---
 ok: false
 panicked: false
-errors: 56
+errors: 40
 --- ast ---
 SOURCE_FILE@0..414: // lex: ok
 // parse: todo
@@ -55,8 +55,7 @@ ARRAY_TYPE@173..196: array[uint[16], #dim=2]
 SCALAR_TYPE@179..187: uint[16]
 DESIGNATOR@183..187: [16]
 LITERAL@184..186: 16
-ERROR@189..193: #dim
-ERROR@193..194: =
+DIM_EXPR@189..196: #dim=2]
 LITERAL@194..195: 2
 NAME@197..198: a
 ERROR@198..199: )
@@ -70,8 +69,7 @@ ARRAY_TYPE@229..254: array[uint[16], #dim=2*n]
 SCALAR_TYPE@235..243: uint[16]
 DESIGNATOR@239..243: [16]
 LITERAL@240..242: 16
-ERROR@245..249: #dim
-ERROR@249..250: =
+DIM_EXPR@245..254: #dim=2*n]
 BIN_EXPR@250..253: 2*n
 LITERAL@250..251: 2
 IDENTIFIER@252..253: n
@@ -87,8 +85,7 @@ ARRAY_TYPE@287..308: array[int[8], #dim=1]
 SCALAR_TYPE@293..299: int[8]
 DESIGNATOR@296..299: [8]
 LITERAL@297..298: 8
-ERROR@301..305: #dim
-ERROR@305..306: =
+DIM_EXPR@301..308: #dim=1]
 LITERAL@306..307: 1
 NAME@309..310: a
 ERROR@310..311: ,
@@ -98,8 +95,7 @@ SCALAR_TYPE@326..344: complex[float[64]]
 SCALAR_TYPE@334..343: float[64]
 DESIGNATOR@339..343: [64]
 LITERAL@340..342: 64
-ERROR@346..350: #dim
-ERROR@350..351: =
+DIM_EXPR@346..353: #dim=3]
 LITERAL@351..352: 3
 NAME@354..355: b
 ERROR@355..356: ,


### PR DESCRIPTION
Last commit supported this in the lexer and the lexed_str IR. This commit support #dim in the parser.

Also, array type declations no longer panic, but rather insert dummy type and a diagnostic.