### PR TITLE
Support for single quoted strings

### DIFF
--- a/crates/oq3_syntax/src/validation.rs
+++ b/crates/oq3_syntax/src/validation.rs
@@ -12,17 +12,10 @@ pub use oq3_parser::T;
 //use rowan::Direction;
 use oq3_lexer::unescape::{self, unescape_literal, Mode};
 
-use crate::{
-    ast::{self, IsString},
-    match_ast, AstNode, HasTextNode, SyntaxError, SyntaxNode, TextSize,
-};
+use crate::{ast, match_ast, AstNode, HasTextNode, SyntaxError, SyntaxNode, TextSize};
 
 // FIXME: GJL, I think I disabled many of these. Some should be used.
 pub(crate) fn validate(root: &SyntaxNode) -> Vec<SyntaxError> {
-    // FIXME: fixme note *not* added by GJL.
-    // * Add unescape validation of raw string literals and raw byte string literals
-    // * Add validation of doc comments are being attached to nodes
-
     let mut errors = Vec::new();
     for node in root.descendants() {
         match_ast! {
@@ -135,15 +128,13 @@ fn validate_literal(literal: ast::Literal, acc: &mut Vec<SyntaxError>) {
     };
 
     match literal.kind() {
-        ast::LiteralKind::String(s) => {
-            if !s.is_raw() {
-                if let Some(without_quotes) = unquote(text, 1, '"') {
-                    unescape_literal(without_quotes, Mode::Str, &mut |range, char| {
-                        if let Err(err) = char {
-                            push_err(1, range.start, err);
-                        }
-                    });
-                }
+        ast::LiteralKind::String(_s) => {
+            if let Some(without_quotes) = unquote(text, 1, '"') {
+                unescape_literal(without_quotes, Mode::Str, &mut |range, char| {
+                    if let Err(err) = char {
+                        push_err(1, range.start, err);
+                    }
+                });
             }
         }
         ast::LiteralKind::BitString(_s) => {

--- a/crates/pipeline-tests/README.md
+++ b/crates/pipeline-tests/README.md
@@ -10,8 +10,21 @@ cargo test -p pipeline-tests -- --list
 
 These tags are at the top of each snippet.
 Set the tags according to what is expected.
+
+* ok -   Stage must complete with no diagnostics.
+* diag - Stage must complete and produce diagnostics (≥1); snapshot verifies content.
+         This is for testing invalid input
+* todo - Stage must complete and produce diagnostics (>=1); snapshot verifies content.
+         Valid input that produces incorrect diagnostics.
+* panic - Stage is expected to panic; harness catches the unwind.
+* skip - Do not assert this stage (optionally skip running it).
 ```
 // lex: ok|diag|todo|panic|skip
 // parse: ok|diag|todo|panic|skip
 // sema: ok|diag|todo|panic|skip
+```
+
+For summary status of tags on snippets
+```sh
+./tools/expect_summary.py
 ```

--- a/crates/pipeline-tests/tests/snapshots/runner__tests__snippets__reference__directives__defcalgrammar.qasm-lex.snap
+++ b/crates/pipeline-tests/tests/snapshots/runner__tests__snippets__reference__directives__defcalgrammar.qasm-lex.snap
@@ -23,18 +23,16 @@ errors: 0
 [5] Whitespace "\n\n" @39..41
 [6] Ident "defcalgrammar" @41..54
 [7] Whitespace " " @54..55
-[8] Unknown "'" @55..56
-[9] Ident "openpulse" @56..65
-[10] Unknown "'" @65..66
-[11] Semi ";" @66..67
-[12] Whitespace "\n" @67..68
-[13] Ident "defcalgrammar" @68..81
-[14] Whitespace " " @81..82
-[15] Literal { kind: Str { terminated: true }, suffix_start: 11 } ""openpulse"" @82..93
-[16] Semi ";" @93..94
-[17] Whitespace "\n" @94..95
-[18] Ident "defcalgrammar" @95..108
-[19] Whitespace " " @108..109
-[20] Literal { kind: BitStr { terminated: true, consecutive_underscores: false }, suffix_start: 5 } ""001"" @109..114
-[21] Semi ";" @114..115
-[22] Whitespace "\n" @115..116
+[8] Literal { kind: Str { terminated: true }, suffix_start: 11 } "'openpulse'" @55..66
+[9] Semi ";" @66..67
+[10] Whitespace "\n" @67..68
+[11] Ident "defcalgrammar" @68..81
+[12] Whitespace " " @81..82
+[13] Literal { kind: Str { terminated: true }, suffix_start: 11 } ""openpulse"" @82..93
+[14] Semi ";" @93..94
+[15] Whitespace "\n" @94..95
+[16] Ident "defcalgrammar" @95..108
+[17] Whitespace " " @108..109
+[18] Literal { kind: BitStr { terminated: true, consecutive_underscores: false }, suffix_start: 5 } ""001"" @109..114
+[19] Semi ";" @114..115
+[20] Whitespace "\n" @115..116

--- a/crates/pipeline-tests/tests/snapshots/runner__tests__snippets__reference__directives__defcalgrammar.qasm-parse.snap
+++ b/crates/pipeline-tests/tests/snapshots/runner__tests__snippets__reference__directives__defcalgrammar.qasm-parse.snap
@@ -7,7 +7,7 @@ expect-parse: Todo
 --- parser ---
 ok: false
 panicked: false
-errors: 5
+errors: 1
 --- ast ---
 SOURCE_FILE@0..116: // lex: ok
 // parse: todo
@@ -17,11 +17,8 @@ defcalgrammar 'openpulse';
 defcalgrammar "openpulse";
 defcalgrammar "001";
 
-DEF_CAL_GRAMMAR@41..56: defcalgrammar '
-ERROR@55..56: '
-EXPR_STMT@56..65: openpulse
-IDENTIFIER@56..65: openpulse
-ERROR@65..66: '
+DEF_CAL_GRAMMAR@41..67: defcalgrammar 'openpulse';
+FILE_PATH@55..66: 'openpulse'
 DEF_CAL_GRAMMAR@68..94: defcalgrammar "openpulse";
 FILE_PATH@82..93: "openpulse"
 DEF_CAL_GRAMMAR@95..115: defcalgrammar "001";

--- a/crates/pipeline-tests/tests/snapshots/runner__tests__snippets__reference__directives__include.qasm-lex.snap
+++ b/crates/pipeline-tests/tests/snapshots/runner__tests__snippets__reference__directives__include.qasm-lex.snap
@@ -23,18 +23,16 @@ errors: 0
 [5] Whitespace "\n\n" @41..43
 [6] Ident "include" @43..50
 [7] Whitespace " " @50..51
-[8] Unknown "'" @51..52
-[9] Ident "foo2" @52..56
-[10] Unknown "'" @56..57
-[11] Semi ";" @57..58
-[12] Whitespace "\n" @58..59
-[13] Ident "include" @59..66
-[14] Whitespace " " @66..67
-[15] Literal { kind: Str { terminated: true }, suffix_start: 5 } ""foo"" @67..72
-[16] Semi ";" @72..73
-[17] Whitespace "\n" @73..74
-[18] Ident "include" @74..81
-[19] Whitespace " " @81..82
-[20] Literal { kind: BitStr { terminated: true, consecutive_underscores: false }, suffix_start: 5 } ""001"" @82..87
-[21] Semi ";" @87..88
-[22] Whitespace "\n" @88..89
+[8] Literal { kind: Str { terminated: true }, suffix_start: 6 } "'foo2'" @51..57
+[9] Semi ";" @57..58
+[10] Whitespace "\n" @58..59
+[11] Ident "include" @59..66
+[12] Whitespace " " @66..67
+[13] Literal { kind: Str { terminated: true }, suffix_start: 5 } ""foo"" @67..72
+[14] Semi ";" @72..73
+[15] Whitespace "\n" @73..74
+[16] Ident "include" @74..81
+[17] Whitespace " " @81..82
+[18] Literal { kind: BitStr { terminated: true, consecutive_underscores: false }, suffix_start: 5 } ""001"" @82..87
+[19] Semi ";" @87..88
+[20] Whitespace "\n" @88..89


### PR DESCRIPTION
For example, this now parses, (and does not produce panic in analysis):

    include 'somefile'

This reduces the number of errors in snippets tests.