### PR TITLE
Fix parsing/analysis of reference parse switch/case test

### DIFF
--- a/crates/oq3_parser/src/grammar/items.rs
+++ b/crates/oq3_parser/src/grammar/items.rs
@@ -112,13 +112,13 @@ fn switch_case_stmt(p: &mut Parser<'_>, m: Marker) {
     expressions::expr(p);
     p.expect(T![')']);
     p.expect(T!['{']);
-    if !p.at(T![case]) {
-        p.error("expecting `case` keyword");
+    if !p.at(T![case]) && !p.at(T![default]) {
+        p.error("expecting `case` or `default` keyword");
     }
     while p.at(T![case]) {
         let m1 = p.start();
         p.bump(T![case]);
-        params::expression_list(p);
+        params::case_value_list(p);
         expressions::try_block_expr(p);
         m1.complete(p, CASE_EXPR);
     }

--- a/crates/oq3_parser/src/grammar/params.rs
+++ b/crates/oq3_parser/src/grammar/params.rs
@@ -4,103 +4,187 @@
 use super::*;
 
 pub(super) fn param_list_gate_params(p: &mut Parser<'_>) {
+    // Gate definition parameter list: (p0, p1, ...)
+    // - parens: yes
+    // - typed: no
+    // - terminator: ')'
     _param_list_openqasm(p, DefFlavor::GateParams);
 }
+
 pub(super) fn param_list_gate_qubits(p: &mut Parser<'_>) {
+    // Gate definition qubit list: q0, q1, ... {
+    // - parens: no
+    // - typed: no
+    // - terminator: '{'
     _param_list_openqasm(p, DefFlavor::GateQubits);
 }
 
 pub(super) fn arg_list_gate_call_qubits(p: &mut Parser<'_>) {
+    // Gate call qubit list: q0, q1, ...;
+    // - parens: no
+    // - typed: no
+    // - terminator: ';'
     _param_list_openqasm(p, DefFlavor::GateCallQubits);
 }
 
 pub(super) fn param_list_def_params(p: &mut Parser<'_>) {
+    // Function definition parameter list: (t0 p0, t1 p1, ...)
+    // - parens: yes
+    // - typed: yes
+    // - terminator: ')'
     _param_list_openqasm(p, DefFlavor::DefParams);
 }
+
 pub(super) fn param_list_defcal_params(p: &mut Parser<'_>) {
+    // DefCal parameter list: (p0, t1 p1, ...)
+    // - parens: yes
+    // - typed: optional
+    // - terminator: ')'
     _param_list_openqasm(p, DefFlavor::DefCalParams);
 }
+
 pub(super) fn param_list_defcal_qubits(p: &mut Parser<'_>) {
+    // DefCal qubit list: q0, q1, ... {   or   q0, q1, ... -> ...
+    // - parens: no
+    // - typed: no
+    // - terminators: '{' or '->'
     _param_list_openqasm(p, DefFlavor::DefCalQubits);
 }
 
 pub(super) fn expression_list(p: &mut Parser<'_>) {
+    // General expression list used in bracket contexts: [e0, e1, ...]
+    // - parens: no
+    // - typed: no
+    // - canonical terminator: ']'
+    // Note: some callers may wrap this between other delimiters and consume them outside.
     _param_list_openqasm(p, DefFlavor::ExpressionList);
+}
+
+pub(super) fn case_value_list(p: &mut Parser<'_>) {
+    // Switch case control values: case e0, e1, ... {
+    // - parens: no
+    // - typed: no
+    // - terminator: '{'
+    _param_list_openqasm(p, DefFlavor::CaseValues);
 }
 
 // Here and elsewhere "Gate" means gate def, and "GateCall" means gate call.
 #[derive(Debug, Clone, Copy)]
 enum DefFlavor {
-    // Same syntax for: gate def params, function call params, gate call params.
-    // But for various reasons, we separate this into GateParams and CallOrGateCallParams
-    // One reason: we can disallow here empty parens in gate def.
-    GateParams, // parens,    no type
-    // For the moment, following is handled in expressions::arg_list instead.
-    GateQubits,     // no parens, no type, '{' terminates
-    GateCallQubits, // no parens, no type, ';' terminates
-    DefParams,      // parens,    type
-    DefCalParams,   // parens,    opt type
-    DefCalQubits,   // no parens, no type, '{' or '->' terminates
+    // Gate definition parameter list: (p0, p1, ...)
+    // - parens: yes
+    // - typed: no
+    // - terminator: ')'
+    GateParams,
+
+    // Gate definition qubit list: q0, q1, ... {
+    // - parens: no
+    // - typed: no
+    // - terminator: '{'
+    GateQubits,
+
+    // Gate call qubit list: q0, q1, ...;
+    // - parens: no
+    // - typed: no
+    // - terminator: ';'
+    GateCallQubits,
+
+    // Function definition parameter list: (t0 p0, t1 p1, ...)
+    // - parens: yes
+    // - typed: yes
+    // - terminator: ')'
+    DefParams,
+
+    // DefCal parameter list: (p0, t1 p1, ...)
+    // - parens: yes
+    // - typed: optional
+    // - terminator: ')'
+    DefCalParams,
+
+    // DefCal qubit list: q0, q1, ... {   or   q0, q1, ... -> ...
+    // - parens: no
+    // - typed: no
+    // - terminators: '{' or '->'
+    DefCalQubits,
+
+    // General expression list (e.g., in index operators): [e0, e1, ...]
+    // - parens: no
+    // - typed: no
+    // - terminator: ']'
     ExpressionList,
+
+    // Switch case control values: case e0, e1, ... {
+    // - parens: no
+    // - typed: no
+    // - terminator: '{'
+    CaseValues,
 }
 
-// Parse a list of parameters.
+// Parse a list of comma-separated items according to the chosen flavor.
+// Notes:
+// - Trailing commas are allowed: after consuming a comma, if the next token
+//   is an end token, the while condition stops the loop before parsing a new item.
+// - For '->' handling: if '->' is a compound token, at_ts()/TokenSet may not
+//   match; hence the simple array + any() checks here.
 fn _param_list_openqasm(p: &mut Parser<'_>, flavor: DefFlavor) {
     use DefFlavor::*;
     let list_marker = p.start();
+
+    // Only GateParams, DefParams, and DefCalParams open with '(' ... ')'.
     let want_parens = matches!(flavor, GateParams | DefParams | DefCalParams);
     match flavor {
         GateParams | DefParams | DefCalParams => p.bump(T!['(']),
-        GateQubits | GateCallQubits | DefCalQubits | ExpressionList => (),
+        GateQubits | GateCallQubits | DefCalQubits | ExpressionList | CaseValues => (),
     }
-    // FIXME: find implementation that does not require [T![')'], T![')']]
-    // I tried using TokenSet, which should give exactly the same result.
-    // But it does not. May be because -> is a compound token.
+
+    // End tokens for each flavor.
     let list_end_tokens = match flavor {
-        // GateParams | DefParams | DefCalParams => {TokenSet::new(&[T![')']])},
-        // GateQubits => {TokenSet::new(&[T!['{']])},
-        // DefCalQubits => {TokenSet::new(&[T!['{'], T![->]])},
         ExpressionList => [T![']'], T![']']],
+        CaseValues => [T!['{'], T!['{']],
         GateParams | DefParams | DefCalParams => [T![')'], T![')']],
-        // When no parens are present `{` terminates the list of parameters.
+        // When no parens are present '{' terminates the gate param list.
         GateQubits => [T!['{'], T!['{']],
         GateCallQubits => [SEMICOLON, SEMICOLON],
         DefCalQubits => [T!['{'], T![->]],
     };
+
     let mut num_params: usize = 0;
-    // Would be nice if we could used the following line instead of hacked roll your own two lines down.
-    //  while !p.at(EOF) && !p.at_ts(list_end_tokens) {
+
+    // Parse items until EOF or an end token is seen.
     while !p.at(EOF) && !list_end_tokens.iter().any(|x| p.at(*x)) {
         let m = p.start();
+
+        // Allowed starts for an item: either a type or a first-token of a param/expression.
         if !(p.current().is_type() || p.at_ts(PARAM_FIRST)) {
             p.error("expected value parameter");
             m.abandon(p);
             break;
         }
+
+        // Dispatch to the appropriate item parser.
         let found_param = match flavor {
-            ExpressionList => {
+            ExpressionList | CaseValues => {
                 m.abandon(p);
                 expressions::expr_or_range_expr(p);
                 true
             }
             GateCallQubits => arg_gate_call_qubit(p, m),
-            // FIXME: this can't work. These two variants have different reqs on params
+            // These two have different requirements but share this entry point.
             DefParams | DefCalParams => param_typed(p, m),
-            // The following is pretty ugly. Probably inefficient as well
+            // Untyped parameters/qubits.
             GateParams | GateQubits | DefCalQubits => param_untyped(p, m),
         };
         if !found_param {
             break;
         }
         num_params += 1;
-        // FIXME: This is only needed to support `->` as terminating tokens.
-        // Not for `{`. But I don't know why. prbly because `->` is compound.
-        // FIXME: use at_ts()
+
+        // If the very next token is an end token, stop
         if list_end_tokens.iter().any(|x| p.at(*x)) {
-            //        if p.at_ts(list_end_tokens) {
             break;
         }
-        // Params must be separated by commas.
+
+        // Items must be separated by commas.
         if !p.at(T![,]) {
             if p.at_ts(PARAM_FIRST) {
                 p.error("Expected `,`");
@@ -108,34 +192,129 @@ fn _param_list_openqasm(p: &mut Parser<'_>, flavor: DefFlavor) {
                 break;
             }
         } else {
-            // We found the expected comma, so consume it.
+            // Found the expected comma; consume and continue.
             p.bump(T![,]);
         }
     }
+
     match flavor {
-        GateParams | ExpressionList if num_params < 1 => {
+        GateParams | ExpressionList | CaseValues if num_params < 1 => {
             p.error("expected one or more parameters");
         }
-        GateParams | ExpressionList => {}
+        GateParams | ExpressionList | CaseValues => {}
         GateQubits | GateCallQubits | DefParams | DefCalParams | DefCalQubits => {}
     };
-    // if let Some(m) = param_marker {
-    //     m.abandon(p);
-    // }
-    // Error if we don't find closing paren.
+
+    // Close parens for the paren-using flavors.
     if want_parens {
         p.expect(T![')']);
     }
+
+    // Complete with the correct node kind for this flavor.
     let kind = match flavor {
         GateQubits => PARAM_LIST,
         DefCalQubits => QUBIT_LIST,
         GateCallQubits => QUBIT_LIST,
-        ExpressionList => EXPRESSION_LIST,
+        ExpressionList | CaseValues => EXPRESSION_LIST,
         DefParams | DefCalParams => TYPED_PARAM_LIST,
         GateParams => PARAM_LIST,
     };
     list_marker.complete(p, kind);
 }
+
+// // Parse a list of parameters.
+// fn _param_list_openqasm(p: &mut Parser<'_>, flavor: DefFlavor) {
+//     use DefFlavor::*;
+//     let list_marker = p.start();
+//     let want_parens = matches!(flavor, GateParams | DefParams | DefCalParams);
+//     match flavor {
+//         GateParams | DefParams | DefCalParams => p.bump(T!['(']),
+//         GateQubits | GateCallQubits | DefCalQubits | ExpressionList | CaseValues => (),
+//     }
+//     // FIXME: find implementation that does not require [T![')'], T![')']]
+//     // I tried using TokenSet, which should give exactly the same result.
+//     // But it does not. May be because -> is a compound token.
+//     let list_end_tokens = match flavor {
+//         // GateParams | DefParams | DefCalParams => {TokenSet::new(&[T![')']])},
+//         // GateQubits => {TokenSet::new(&[T!['{']])},
+//         // DefCalQubits => {TokenSet::new(&[T!['{'], T![->]])},
+//         ExpressionList => [T![']'], T![']']],
+//         CaseValues => [T!['{'], T!['{']],
+//         GateParams | DefParams | DefCalParams => [T![')'], T![')']],
+//         // When no parens are present `{` terminates the list of parameters.
+//         GateQubits => [T!['{'], T!['{']],
+//         GateCallQubits => [SEMICOLON, SEMICOLON],
+//         DefCalQubits => [T!['{'], T![->]],
+//     };
+//     let mut num_params: usize = 0;
+//     // Would be nice if we could used the following line instead of hacked roll your own two lines down.
+//     //  while !p.at(EOF) && !p.at_ts(list_end_tokens) {
+//     while !p.at(EOF) && !list_end_tokens.iter().any(|x| p.at(*x)) {
+//         let m = p.start();
+//         if !(p.current().is_type() || p.at_ts(PARAM_FIRST)) {
+//             p.error("expected value parameter");
+//             m.abandon(p);
+//             break;
+//         }
+//         let found_param = match flavor {
+//             ExpressionList | CaseValues => {
+//                 m.abandon(p);
+//                 expressions::expr_or_range_expr(p);
+//                 true
+//             }
+//             GateCallQubits => arg_gate_call_qubit(p, m),
+//             // FIXME: this can't work. These two variants have different reqs on params
+//             DefParams | DefCalParams => param_typed(p, m),
+//             // The following is pretty ugly. Probably inefficient as well
+//             GateParams | GateQubits | DefCalQubits => param_untyped(p, m),
+//         };
+//         if !found_param {
+//             break;
+//         }
+//         num_params += 1;
+//         // FIXME: This is only needed to support `->` as terminating tokens.
+//         // Not for `{`. But I don't know why. prbly because `->` is compound.
+//         // FIXME: use at_ts()
+//         if list_end_tokens.iter().any(|x| p.at(*x)) {
+//             //        if p.at_ts(list_end_tokens) {
+//             break;
+//         }
+//         // Params must be separated by commas.
+//         if !p.at(T![,]) {
+//             if p.at_ts(PARAM_FIRST) {
+//                 p.error("Expected `,`");
+//             } else {
+//                 break;
+//             }
+//         } else {
+//             // We found the expected comma, so consume it.
+//             p.bump(T![,]);
+//         }
+//     }
+//     match flavor {
+//         GateParams | ExpressionList | CaseValues if num_params < 1 => {
+//             p.error("expected one or more parameters");
+//         }
+//         GateParams | ExpressionList | CaseValues => {}
+//         GateQubits | GateCallQubits | DefParams | DefCalParams | DefCalQubits => {}
+//     };
+//     // if let Some(m) = param_marker {
+//     //     m.abandon(p);
+//     // }
+//     // Error if we don't find closing paren.
+//     if want_parens {
+//         p.expect(T![')']);
+//     }
+//     let kind = match flavor {
+//         GateQubits => PARAM_LIST,
+//         DefCalQubits => QUBIT_LIST,
+//         GateCallQubits => QUBIT_LIST,
+//         ExpressionList | CaseValues => EXPRESSION_LIST,
+//         DefParams | DefCalParams => TYPED_PARAM_LIST,
+//         GateParams => PARAM_LIST,
+//     };
+//     list_marker.complete(p, kind);
+// }
 
 const PATTERN_FIRST: TokenSet = expressions::LITERAL_FIRST
     .union(expressions::atom::PATH_FIRST)

--- a/crates/pipeline-tests/tests/snapshots/runner__tests__snippets__reference__control_flow__switch.qasm-lex.snap
+++ b/crates/pipeline-tests/tests/snapshots/runner__tests__snippets__reference__control_flow__switch.qasm-lex.snap
@@ -6,8 +6,14 @@ id: tests/snippets/reference/control_flow/switch.qasm
 expect-lex: Ok
 --- source ---
 // lex: ok
-// parse: todo
-// sema: skip
+// parse: ok
+// sema: ok
+
+include "stdgates.inc";
+
+int i = 1;
+int j = 2;
+int k = 3;
 
 switch (i) {
   case 0 {
@@ -41,132 +47,164 @@ ok: true
 errors: 0
 [0] LineComment "// lex: ok" @0..10
 [1] Whitespace "\n" @10..11
-[2] LineComment "// parse: todo" @11..25
-[3] Whitespace "\n" @25..26
-[4] LineComment "// sema: skip" @26..39
-[5] Whitespace "\n\n" @39..41
-[6] Ident "switch" @41..47
-[7] Whitespace " " @47..48
-[8] OpenParen "(" @48..49
-[9] Ident "i" @49..50
-[10] CloseParen ")" @50..51
-[11] Whitespace " " @51..52
-[12] OpenBrace "{" @52..53
-[13] Whitespace "\n  " @53..56
-[14] Ident "case" @56..60
-[15] Whitespace " " @60..61
-[16] Literal { kind: Int { base: Decimal, empty_int: false }, suffix_start: 1 } "0" @61..62
-[17] Whitespace " " @62..63
-[18] OpenBrace "{" @63..64
-[19] Whitespace "\n    " @64..69
-[20] Ident "x" @69..70
-[21] Whitespace " " @70..71
-[22] HardwareIdent "$0" @71..73
-[23] Semi ";" @73..74
-[24] Whitespace "\n  " @74..77
-[25] CloseBrace "}" @77..78
-[26] Whitespace "\n  " @78..81
-[27] Ident "case" @81..85
-[28] Whitespace " " @85..86
-[29] Literal { kind: Int { base: Decimal, empty_int: false }, suffix_start: 1 } "1" @86..87
-[30] Comma "," @87..88
-[31] Whitespace " " @88..89
-[32] Literal { kind: Int { base: Decimal, empty_int: false }, suffix_start: 1 } "2" @89..90
-[33] Whitespace " " @90..91
-[34] OpenBrace "{" @91..92
-[35] Whitespace "\n    " @92..97
-[36] Ident "x" @97..98
-[37] Whitespace " " @98..99
-[38] HardwareIdent "$0" @99..101
-[39] Semi ";" @101..102
-[40] Whitespace "\n    " @102..107
-[41] Ident "z" @107..108
-[42] Whitespace " " @108..109
-[43] HardwareIdent "$1" @109..111
-[44] Semi ";" @111..112
-[45] Whitespace "\n  " @112..115
-[46] CloseBrace "}" @115..116
-[47] Whitespace "\n  " @116..119
-[48] Ident "case" @119..123
-[49] Whitespace " " @123..124
-[50] Literal { kind: Int { base: Decimal, empty_int: false }, suffix_start: 1 } "3" @124..125
-[51] Comma "," @125..126
-[52] Whitespace " " @126..127
-[53] OpenBrace "{" @127..128
-[54] Whitespace "\n  " @128..131
-[55] CloseBrace "}" @131..132
-[56] Whitespace "\n  " @132..135
-[57] Ident "default" @135..142
-[58] Whitespace " " @142..143
-[59] OpenBrace "{" @143..144
-[60] Whitespace "\n    " @144..149
-[61] Ident "cx" @149..151
-[62] Whitespace " " @151..152
-[63] HardwareIdent "$0" @152..154
-[64] Comma "," @154..155
-[65] Whitespace " " @155..156
-[66] HardwareIdent "$1" @156..158
-[67] Semi ";" @158..159
-[68] Whitespace "\n  " @159..162
-[69] CloseBrace "}" @162..163
-[70] Whitespace "\n" @163..164
-[71] CloseBrace "}" @164..165
-[72] Whitespace "\n\n" @165..167
-[73] Ident "switch" @167..173
-[74] Whitespace " " @173..174
-[75] OpenParen "(" @174..175
-[76] Ident "i" @175..176
-[77] Whitespace " " @176..177
-[78] Plus "+" @177..178
-[79] Whitespace " " @178..179
-[80] Ident "j" @179..180
-[81] CloseParen ")" @180..181
-[82] Whitespace " " @181..182
-[83] OpenBrace "{" @182..183
-[84] Whitespace "\n  " @183..186
-[85] Ident "default" @186..193
-[86] Whitespace " " @193..194
-[87] OpenBrace "{" @194..195
-[88] Whitespace "\n    " @195..200
-[89] Ident "switch" @200..206
-[90] Whitespace " " @206..207
-[91] OpenParen "(" @207..208
-[92] Literal { kind: Int { base: Decimal, empty_int: false }, suffix_start: 1 } "2" @208..209
-[93] Whitespace " " @209..210
-[94] Star "*" @210..211
-[95] Whitespace " " @211..212
-[96] Ident "k" @212..213
-[97] CloseParen ")" @213..214
-[98] Whitespace " " @214..215
-[99] OpenBrace "{" @215..216
-[100] Whitespace "\n      " @216..223
-[101] Ident "case" @223..227
-[102] Whitespace " " @227..228
-[103] Literal { kind: Int { base: Decimal, empty_int: false }, suffix_start: 1 } "0" @228..229
-[104] Whitespace " " @229..230
-[105] OpenBrace "{" @230..231
-[106] Whitespace "\n        " @231..240
-[107] Ident "x" @240..241
-[108] Whitespace " " @241..242
-[109] HardwareIdent "$0" @242..244
-[110] Semi ";" @244..245
-[111] Whitespace "\n      " @245..252
-[112] CloseBrace "}" @252..253
-[113] Whitespace "\n      " @253..260
-[114] Ident "default" @260..267
-[115] Whitespace " " @267..268
-[116] OpenBrace "{" @268..269
-[117] Whitespace "\n        " @269..278
-[118] Ident "z" @278..279
-[119] Whitespace " " @279..280
-[120] HardwareIdent "$0" @280..282
-[121] Semi ";" @282..283
-[122] Whitespace "\n      " @283..290
-[123] CloseBrace "}" @290..291
-[124] Whitespace "\n    " @291..296
-[125] CloseBrace "}" @296..297
-[126] Whitespace "\n  " @297..300
-[127] CloseBrace "}" @300..301
-[128] Whitespace "\n" @301..302
-[129] CloseBrace "}" @302..303
-[130] Whitespace "\n" @303..304
+[2] LineComment "// parse: ok" @11..23
+[3] Whitespace "\n" @23..24
+[4] LineComment "// sema: ok" @24..35
+[5] Whitespace "\n\n" @35..37
+[6] Ident "include" @37..44
+[7] Whitespace " " @44..45
+[8] Literal { kind: Str { terminated: true }, suffix_start: 14 } ""stdgates.inc"" @45..59
+[9] Semi ";" @59..60
+[10] Whitespace "\n\n" @60..62
+[11] Ident "int" @62..65
+[12] Whitespace " " @65..66
+[13] Ident "i" @66..67
+[14] Whitespace " " @67..68
+[15] Eq "=" @68..69
+[16] Whitespace " " @69..70
+[17] Literal { kind: Int { base: Decimal, empty_int: false }, suffix_start: 1 } "1" @70..71
+[18] Semi ";" @71..72
+[19] Whitespace "\n" @72..73
+[20] Ident "int" @73..76
+[21] Whitespace " " @76..77
+[22] Ident "j" @77..78
+[23] Whitespace " " @78..79
+[24] Eq "=" @79..80
+[25] Whitespace " " @80..81
+[26] Literal { kind: Int { base: Decimal, empty_int: false }, suffix_start: 1 } "2" @81..82
+[27] Semi ";" @82..83
+[28] Whitespace "\n" @83..84
+[29] Ident "int" @84..87
+[30] Whitespace " " @87..88
+[31] Ident "k" @88..89
+[32] Whitespace " " @89..90
+[33] Eq "=" @90..91
+[34] Whitespace " " @91..92
+[35] Literal { kind: Int { base: Decimal, empty_int: false }, suffix_start: 1 } "3" @92..93
+[36] Semi ";" @93..94
+[37] Whitespace "\n\n" @94..96
+[38] Ident "switch" @96..102
+[39] Whitespace " " @102..103
+[40] OpenParen "(" @103..104
+[41] Ident "i" @104..105
+[42] CloseParen ")" @105..106
+[43] Whitespace " " @106..107
+[44] OpenBrace "{" @107..108
+[45] Whitespace "\n  " @108..111
+[46] Ident "case" @111..115
+[47] Whitespace " " @115..116
+[48] Literal { kind: Int { base: Decimal, empty_int: false }, suffix_start: 1 } "0" @116..117
+[49] Whitespace " " @117..118
+[50] OpenBrace "{" @118..119
+[51] Whitespace "\n    " @119..124
+[52] Ident "x" @124..125
+[53] Whitespace " " @125..126
+[54] HardwareIdent "$0" @126..128
+[55] Semi ";" @128..129
+[56] Whitespace "\n  " @129..132
+[57] CloseBrace "}" @132..133
+[58] Whitespace "\n  " @133..136
+[59] Ident "case" @136..140
+[60] Whitespace " " @140..141
+[61] Literal { kind: Int { base: Decimal, empty_int: false }, suffix_start: 1 } "1" @141..142
+[62] Comma "," @142..143
+[63] Whitespace " " @143..144
+[64] Literal { kind: Int { base: Decimal, empty_int: false }, suffix_start: 1 } "2" @144..145
+[65] Whitespace " " @145..146
+[66] OpenBrace "{" @146..147
+[67] Whitespace "\n    " @147..152
+[68] Ident "x" @152..153
+[69] Whitespace " " @153..154
+[70] HardwareIdent "$0" @154..156
+[71] Semi ";" @156..157
+[72] Whitespace "\n    " @157..162
+[73] Ident "z" @162..163
+[74] Whitespace " " @163..164
+[75] HardwareIdent "$1" @164..166
+[76] Semi ";" @166..167
+[77] Whitespace "\n  " @167..170
+[78] CloseBrace "}" @170..171
+[79] Whitespace "\n  " @171..174
+[80] Ident "case" @174..178
+[81] Whitespace " " @178..179
+[82] Literal { kind: Int { base: Decimal, empty_int: false }, suffix_start: 1 } "3" @179..180
+[83] Comma "," @180..181
+[84] Whitespace " " @181..182
+[85] OpenBrace "{" @182..183
+[86] Whitespace "\n  " @183..186
+[87] CloseBrace "}" @186..187
+[88] Whitespace "\n  " @187..190
+[89] Ident "default" @190..197
+[90] Whitespace " " @197..198
+[91] OpenBrace "{" @198..199
+[92] Whitespace "\n    " @199..204
+[93] Ident "cx" @204..206
+[94] Whitespace " " @206..207
+[95] HardwareIdent "$0" @207..209
+[96] Comma "," @209..210
+[97] Whitespace " " @210..211
+[98] HardwareIdent "$1" @211..213
+[99] Semi ";" @213..214
+[100] Whitespace "\n  " @214..217
+[101] CloseBrace "}" @217..218
+[102] Whitespace "\n" @218..219
+[103] CloseBrace "}" @219..220
+[104] Whitespace "\n\n" @220..222
+[105] Ident "switch" @222..228
+[106] Whitespace " " @228..229
+[107] OpenParen "(" @229..230
+[108] Ident "i" @230..231
+[109] Whitespace " " @231..232
+[110] Plus "+" @232..233
+[111] Whitespace " " @233..234
+[112] Ident "j" @234..235
+[113] CloseParen ")" @235..236
+[114] Whitespace " " @236..237
+[115] OpenBrace "{" @237..238
+[116] Whitespace "\n  " @238..241
+[117] Ident "default" @241..248
+[118] Whitespace " " @248..249
+[119] OpenBrace "{" @249..250
+[120] Whitespace "\n    " @250..255
+[121] Ident "switch" @255..261
+[122] Whitespace " " @261..262
+[123] OpenParen "(" @262..263
+[124] Literal { kind: Int { base: Decimal, empty_int: false }, suffix_start: 1 } "2" @263..264
+[125] Whitespace " " @264..265
+[126] Star "*" @265..266
+[127] Whitespace " " @266..267
+[128] Ident "k" @267..268
+[129] CloseParen ")" @268..269
+[130] Whitespace " " @269..270
+[131] OpenBrace "{" @270..271
+[132] Whitespace "\n      " @271..278
+[133] Ident "case" @278..282
+[134] Whitespace " " @282..283
+[135] Literal { kind: Int { base: Decimal, empty_int: false }, suffix_start: 1 } "0" @283..284
+[136] Whitespace " " @284..285
+[137] OpenBrace "{" @285..286
+[138] Whitespace "\n        " @286..295
+[139] Ident "x" @295..296
+[140] Whitespace " " @296..297
+[141] HardwareIdent "$0" @297..299
+[142] Semi ";" @299..300
+[143] Whitespace "\n      " @300..307
+[144] CloseBrace "}" @307..308
+[145] Whitespace "\n      " @308..315
+[146] Ident "default" @315..322
+[147] Whitespace " " @322..323
+[148] OpenBrace "{" @323..324
+[149] Whitespace "\n        " @324..333
+[150] Ident "z" @333..334
+[151] Whitespace " " @334..335
+[152] HardwareIdent "$0" @335..337
+[153] Semi ";" @337..338
+[154] Whitespace "\n      " @338..345
+[155] CloseBrace "}" @345..346
+[156] Whitespace "\n    " @346..351
+[157] CloseBrace "}" @351..352
+[158] Whitespace "\n  " @352..355
+[159] CloseBrace "}" @355..356
+[160] Whitespace "\n" @356..357
+[161] CloseBrace "}" @357..358
+[162] Whitespace "\n" @358..359

--- a/crates/pipeline-tests/tests/snapshots/runner__tests__snippets__reference__control_flow__switch.qasm-parse.snap
+++ b/crates/pipeline-tests/tests/snapshots/runner__tests__snippets__reference__control_flow__switch.qasm-parse.snap
@@ -3,15 +3,21 @@ source: crates/pipeline-tests/tests/runner.rs
 expression: parse_snap
 ---
 id: tests/snippets/reference/control_flow/switch.qasm
-expect-parse: Todo
+expect-parse: Ok
 --- parser ---
-ok: false
+ok: true
 panicked: false
-errors: 2
+errors: 0
 --- ast ---
-SOURCE_FILE@0..304: // lex: ok
-// parse: todo
-// sema: skip
+SOURCE_FILE@0..359: // lex: ok
+// parse: ok
+// sema: ok
+
+include "stdgates.inc";
+
+int i = 1;
+int j = 2;
+int k = 3;
 
 switch (i) {
   case 0 {
@@ -41,7 +47,21 @@ switch (i + j) {
   }
 }
 
-SWITCH_CASE_STMT@41..165: switch (i) {
+INCLUDE@37..60: include "stdgates.inc";
+FILE_PATH@45..59: "stdgates.inc"
+CLASSICAL_DECLARATION_STATEMENT@62..72: int i = 1;
+SCALAR_TYPE@62..65: int
+NAME@66..67: i
+LITERAL@70..71: 1
+CLASSICAL_DECLARATION_STATEMENT@73..83: int j = 2;
+SCALAR_TYPE@73..76: int
+NAME@77..78: j
+LITERAL@81..82: 2
+CLASSICAL_DECLARATION_STATEMENT@84..94: int k = 3;
+SCALAR_TYPE@84..87: int
+NAME@88..89: k
+LITERAL@92..93: 3
+SWITCH_CASE_STMT@96..220: switch (i) {
   case 0 {
     x $0;
   }
@@ -55,57 +75,57 @@ SWITCH_CASE_STMT@41..165: switch (i) {
     cx $0, $1;
   }
 }
-IDENTIFIER@49..50: i
-CASE_EXPR@56..78: case 0 {
+IDENTIFIER@104..105: i
+CASE_EXPR@111..133: case 0 {
     x $0;
   }
-EXPRESSION_LIST@61..62: 0
-LITERAL@61..62: 0
-BLOCK_EXPR@63..78: {
+EXPRESSION_LIST@116..117: 0
+LITERAL@116..117: 0
+BLOCK_EXPR@118..133: {
     x $0;
   }
-EXPR_STMT@69..74: x $0;
-GATE_CALL_EXPR@69..73: x $0
-IDENTIFIER@69..70: x
-QUBIT_LIST@71..73: $0
-HARDWARE_QUBIT@71..73: $0
-CASE_EXPR@81..116: case 1, 2 {
-    x $0;
-    z $1;
-  }
-EXPRESSION_LIST@86..90: 1, 2
-LITERAL@86..87: 1
-LITERAL@89..90: 2
-BLOCK_EXPR@91..116: {
+EXPR_STMT@124..129: x $0;
+GATE_CALL_EXPR@124..128: x $0
+IDENTIFIER@124..125: x
+QUBIT_LIST@126..128: $0
+HARDWARE_QUBIT@126..128: $0
+CASE_EXPR@136..171: case 1, 2 {
     x $0;
     z $1;
   }
-EXPR_STMT@97..102: x $0;
-GATE_CALL_EXPR@97..101: x $0
-IDENTIFIER@97..98: x
-QUBIT_LIST@99..101: $0
-HARDWARE_QUBIT@99..101: $0
-EXPR_STMT@107..112: z $1;
-GATE_CALL_EXPR@107..111: z $1
-IDENTIFIER@107..108: z
-QUBIT_LIST@109..111: $1
-HARDWARE_QUBIT@109..111: $1
-CASE_EXPR@119..132: case 3, {
+EXPRESSION_LIST@141..145: 1, 2
+LITERAL@141..142: 1
+LITERAL@144..145: 2
+BLOCK_EXPR@146..171: {
+    x $0;
+    z $1;
   }
-EXPRESSION_LIST@124..126: 3,
-LITERAL@124..125: 3
-BLOCK_EXPR@127..132: {
+EXPR_STMT@152..157: x $0;
+GATE_CALL_EXPR@152..156: x $0
+IDENTIFIER@152..153: x
+QUBIT_LIST@154..156: $0
+HARDWARE_QUBIT@154..156: $0
+EXPR_STMT@162..167: z $1;
+GATE_CALL_EXPR@162..166: z $1
+IDENTIFIER@162..163: z
+QUBIT_LIST@164..166: $1
+HARDWARE_QUBIT@164..166: $1
+CASE_EXPR@174..187: case 3, {
   }
-BLOCK_EXPR@143..163: {
+EXPRESSION_LIST@179..181: 3,
+LITERAL@179..180: 3
+BLOCK_EXPR@182..187: {
+  }
+BLOCK_EXPR@198..218: {
     cx $0, $1;
   }
-EXPR_STMT@149..159: cx $0, $1;
-GATE_CALL_EXPR@149..158: cx $0, $1
-IDENTIFIER@149..151: cx
-QUBIT_LIST@152..158: $0, $1
-HARDWARE_QUBIT@152..154: $0
-HARDWARE_QUBIT@156..158: $1
-SWITCH_CASE_STMT@167..303: switch (i + j) {
+EXPR_STMT@204..214: cx $0, $1;
+GATE_CALL_EXPR@204..213: cx $0, $1
+IDENTIFIER@204..206: cx
+QUBIT_LIST@207..213: $0, $1
+HARDWARE_QUBIT@207..209: $0
+HARDWARE_QUBIT@211..213: $1
+SWITCH_CASE_STMT@222..358: switch (i + j) {
   default {
     switch (2 * k) {
       case 0 {
@@ -117,10 +137,10 @@ SWITCH_CASE_STMT@167..303: switch (i + j) {
     }
   }
 }
-BIN_EXPR@175..180: i + j
-IDENTIFIER@175..176: i
-IDENTIFIER@179..180: j
-BLOCK_EXPR@194..301: {
+BIN_EXPR@230..235: i + j
+IDENTIFIER@230..231: i
+IDENTIFIER@234..235: j
+BLOCK_EXPR@249..356: {
     switch (2 * k) {
       case 0 {
         x $0;
@@ -130,7 +150,7 @@ BLOCK_EXPR@194..301: {
       }
     }
   }
-SWITCH_CASE_STMT@200..297: switch (2 * k) {
+SWITCH_CASE_STMT@255..352: switch (2 * k) {
       case 0 {
         x $0;
       }
@@ -138,27 +158,27 @@ SWITCH_CASE_STMT@200..297: switch (2 * k) {
         z $0;
       }
     }
-BIN_EXPR@208..213: 2 * k
-LITERAL@208..209: 2
-IDENTIFIER@212..213: k
-CASE_EXPR@223..253: case 0 {
+BIN_EXPR@263..268: 2 * k
+LITERAL@263..264: 2
+IDENTIFIER@267..268: k
+CASE_EXPR@278..308: case 0 {
         x $0;
       }
-EXPRESSION_LIST@228..229: 0
-LITERAL@228..229: 0
-BLOCK_EXPR@230..253: {
+EXPRESSION_LIST@283..284: 0
+LITERAL@283..284: 0
+BLOCK_EXPR@285..308: {
         x $0;
       }
-EXPR_STMT@240..245: x $0;
-GATE_CALL_EXPR@240..244: x $0
-IDENTIFIER@240..241: x
-QUBIT_LIST@242..244: $0
-HARDWARE_QUBIT@242..244: $0
-BLOCK_EXPR@268..291: {
+EXPR_STMT@295..300: x $0;
+GATE_CALL_EXPR@295..299: x $0
+IDENTIFIER@295..296: x
+QUBIT_LIST@297..299: $0
+HARDWARE_QUBIT@297..299: $0
+BLOCK_EXPR@323..346: {
         z $0;
       }
-EXPR_STMT@278..283: z $0;
-GATE_CALL_EXPR@278..282: z $0
-IDENTIFIER@278..279: z
-QUBIT_LIST@280..282: $0
-HARDWARE_QUBIT@280..282: $0
+EXPR_STMT@333..338: z $0;
+GATE_CALL_EXPR@333..337: z $0
+IDENTIFIER@333..334: z
+QUBIT_LIST@335..337: $0
+HARDWARE_QUBIT@335..337: $0

--- a/crates/pipeline-tests/tests/snapshots/runner__tests__snippets__reference__control_flow__switch.qasm-sema.snap
+++ b/crates/pipeline-tests/tests/snapshots/runner__tests__snippets__reference__control_flow__switch.qasm-sema.snap
@@ -3,10 +3,18 @@ source: crates/pipeline-tests/tests/runner.rs
 expression: sema_snap
 ---
 id: tests/snippets/reference/control_flow/switch.qasm
-expect-sema: Skip
+expect-sema: Ok
 --- sema ---
 ok: true
 panicked: false
 errors: 0
 --- asg ---
-(no asg)
+DeclareClassical(DeclareClassical { name: Ok(SymbolId(39)), initializer: Some(TExpr { expression: Cast(Cast { operand: TExpr { expression: Literal(Int(IntLiteral { value: 1, sign: true })), ty: Int(Some(128), True) }, typ: Int(None, False) }), ty: Int(None, False) }) })
+
+DeclareClassical(DeclareClassical { name: Ok(SymbolId(40)), initializer: Some(TExpr { expression: Cast(Cast { operand: TExpr { expression: Literal(Int(IntLiteral { value: 2, sign: true })), ty: Int(Some(128), True) }, typ: Int(None, False) }), ty: Int(None, False) }) })
+
+DeclareClassical(DeclareClassical { name: Ok(SymbolId(41)), initializer: Some(TExpr { expression: Cast(Cast { operand: TExpr { expression: Literal(Int(IntLiteral { value: 3, sign: true })), ty: Int(Some(128), True) }, typ: Int(None, False) }), ty: Int(None, False) }) })
+
+SwitchCaseStmt(SwitchCaseStmt { control: TExpr { expression: Identifier(Ok(SymbolId(39))), ty: Int(None, False) }, cases: [CaseExpr { control_values: [TExpr { expression: Literal(Int(IntLiteral { value: 0, sign: true })), ty: Int(Some(128), True) }], statements: [GateCall(GateCall { name: Ok(SymbolId(7)), params: None, qubits: [TExpr { expression: GateOperand(HardwareQubit(HardwareQubit { identifier: "$0" })), ty: HardwareQubit }], modifiers: [] })] }, CaseExpr { control_values: [TExpr { expression: Literal(Int(IntLiteral { value: 1, sign: true })), ty: Int(Some(128), True) }, TExpr { expression: Literal(Int(IntLiteral { value: 2, sign: true })), ty: Int(Some(128), True) }], statements: [GateCall(GateCall { name: Ok(SymbolId(7)), params: None, qubits: [TExpr { expression: GateOperand(HardwareQubit(HardwareQubit { identifier: "$0" })), ty: HardwareQubit }], modifiers: [] }), GateCall(GateCall { name: Ok(SymbolId(9)), params: None, qubits: [TExpr { expression: GateOperand(HardwareQubit(HardwareQubit { identifier: "$1" })), ty: HardwareQubit }], modifiers: [] })] }, CaseExpr { control_values: [TExpr { expression: Literal(Int(IntLiteral { value: 3, sign: true })), ty: Int(Some(128), True) }], statements: [] }], default_block: Some([GateCall(GateCall { name: Ok(SymbolId(25)), params: None, qubits: [TExpr { expression: GateOperand(HardwareQubit(HardwareQubit { identifier: "$0" })), ty: HardwareQubit }, TExpr { expression: GateOperand(HardwareQubit(HardwareQubit { identifier: "$1" })), ty: HardwareQubit }], modifiers: [] })]) })
+
+SwitchCaseStmt(SwitchCaseStmt { control: TExpr { expression: BinaryExpr(BinaryExpr { op: ArithOp(Add), left: TExpr { expression: Identifier(Ok(SymbolId(39))), ty: Int(None, False) }, right: TExpr { expression: Identifier(Ok(SymbolId(40))), ty: Int(None, False) } }), ty: Int(None, False) }, cases: [], default_block: Some([SwitchCaseStmt(SwitchCaseStmt { control: TExpr { expression: BinaryExpr(BinaryExpr { op: ArithOp(Mul), left: TExpr { expression: Cast(Cast { operand: TExpr { expression: Literal(Int(IntLiteral { value: 2, sign: true })), ty: Int(Some(128), True) }, typ: Int(None, False) }), ty: Int(None, False) }, right: TExpr { expression: Identifier(Ok(SymbolId(41))), ty: Int(None, False) } }), ty: Int(None, False) }, cases: [CaseExpr { control_values: [TExpr { expression: Literal(Int(IntLiteral { value: 0, sign: true })), ty: Int(Some(128), True) }], statements: [GateCall(GateCall { name: Ok(SymbolId(7)), params: None, qubits: [TExpr { expression: GateOperand(HardwareQubit(HardwareQubit { identifier: "$0" })), ty: HardwareQubit }], modifiers: [] })] }], default_block: Some([GateCall(GateCall { name: Ok(SymbolId(9)), params: None, qubits: [TExpr { expression: GateOperand(HardwareQubit(HardwareQubit { identifier: "$0" })), ty: HardwareQubit }], modifiers: [] })]) })]) })

--- a/crates/pipeline-tests/tests/snippets/reference/control_flow/switch.qasm
+++ b/crates/pipeline-tests/tests/snippets/reference/control_flow/switch.qasm
@@ -1,6 +1,12 @@
 // lex: ok
-// parse: todo
-// sema: skip
+// parse: ok
+// sema: ok
+
+include "stdgates.inc";
+
+int i = 1;
+int j = 2;
+int k = 3;
 
 switch (i) {
   case 0 {


### PR DESCRIPTION
Fixes a few bugs in switch/case parsing

* Allows no case, only default
* allowing trailing commas in some lists. It is in the reference parser. I am not sure about the spec.

This fix is reflected in the snippets tests.

Comments were formatted and cleaned up with a GPT-5 agent