### PR TITLE
Fix bug in lexing pragma

### DIFF
--- a/crates/oq3_lexer/src/lib.rs
+++ b/crates/oq3_lexer/src/lib.rs
@@ -301,7 +301,7 @@ impl Cursor<'_> {
 
             // Identifier (this should be checked after other variant that can
             // start as identifier).
-            c if is_id_start(c) => self.ident_or_unknown_prefix(),
+            c if is_id_start(c) => self.ident_or_unknown_prefix(c),
 
             // Numeric literal.
             c @ '0'..='9' => {
@@ -502,10 +502,12 @@ impl Cursor<'_> {
         Whitespace
     }
 
-    fn ident_or_unknown_prefix(&mut self) -> TokenKind {
+    fn ident_or_unknown_prefix(&mut self, c: char) -> TokenKind {
         debug_assert!(is_id_start(self.prev()));
 
-        if self.prev() == 'p' && self.first() == 'r' {
+        // First see if we have "pragma". Everything till the end of the
+        // line is included in one token.
+        if c == 'p' && self.first() == 'r' {
             self.bump();
             if self.first() == 'a' {
                 self.bump();

--- a/crates/pipeline-tests/tests/snapshots/runner__tests__snippets__reference__directives__pragma.qasm-lex.snap
+++ b/crates/pipeline-tests/tests/snapshots/runner__tests__snippets__reference__directives__pragma.qasm-lex.snap
@@ -6,8 +6,8 @@ id: tests/snippets/reference/directives/pragma.qasm
 expect-lex: Ok
 --- source ---
 // lex: ok
-// parse: todo
-// sema: todo
+// parse: ok
+// sema: ok
 
 pragma IO_BIND[2:3]
 #pragma  __directive_info__ 0
@@ -16,11 +16,11 @@ ok: true
 errors: 0
 [0] LineComment "// lex: ok" @0..10
 [1] Whitespace "\n" @10..11
-[2] LineComment "// parse: todo" @11..25
-[3] Whitespace "\n" @25..26
-[4] LineComment "// sema: todo" @26..39
-[5] Whitespace "\n\n" @39..41
-[6] Pragma "pragma IO_BIND[2:3]" @41..60
-[7] Whitespace "\n" @60..61
-[8] Pragma "#pragma  __directive_info__ 0" @61..90
-[9] Whitespace "\n" @90..91
+[2] LineComment "// parse: ok" @11..23
+[3] Whitespace "\n" @23..24
+[4] LineComment "// sema: ok" @24..35
+[5] Whitespace "\n\n" @35..37
+[6] Pragma "pragma IO_BIND[2:3]" @37..56
+[7] Whitespace "\n" @56..57
+[8] Pragma "#pragma  __directive_info__ 0" @57..86
+[9] Whitespace "\n" @86..87

--- a/crates/pipeline-tests/tests/snapshots/runner__tests__snippets__reference__directives__pragma.qasm-parse.snap
+++ b/crates/pipeline-tests/tests/snapshots/runner__tests__snippets__reference__directives__pragma.qasm-parse.snap
@@ -3,18 +3,18 @@ source: crates/pipeline-tests/tests/runner.rs
 expression: parse_snap
 ---
 id: tests/snippets/reference/directives/pragma.qasm
-expect-parse: Todo
+expect-parse: Ok
 --- parser ---
 ok: true
 panicked: false
 errors: 0
 --- ast ---
-SOURCE_FILE@0..91: // lex: ok
-// parse: todo
-// sema: todo
+SOURCE_FILE@0..87: // lex: ok
+// parse: ok
+// sema: ok
 
 pragma IO_BIND[2:3]
 #pragma  __directive_info__ 0
 
-PRAGMA_STATEMENT@41..60: pragma IO_BIND[2:3]
-PRAGMA_STATEMENT@61..90: #pragma  __directive_info__ 0
+PRAGMA_STATEMENT@37..56: pragma IO_BIND[2:3]
+PRAGMA_STATEMENT@57..86: #pragma  __directive_info__ 0

--- a/crates/pipeline-tests/tests/snapshots/runner__tests__snippets__reference__directives__pragma.qasm-sema.snap
+++ b/crates/pipeline-tests/tests/snapshots/runner__tests__snippets__reference__directives__pragma.qasm-sema.snap
@@ -3,7 +3,7 @@ source: crates/pipeline-tests/tests/runner.rs
 expression: sema_snap
 ---
 id: tests/snippets/reference/directives/pragma.qasm
-expect-sema: Todo
+expect-sema: Ok
 --- sema ---
 ok: true
 panicked: false

--- a/crates/pipeline-tests/tests/snippets/reference/directives/pragma.qasm
+++ b/crates/pipeline-tests/tests/snippets/reference/directives/pragma.qasm
@@ -1,6 +1,6 @@
 // lex: ok
-// parse: todo
-// sema: todo
+// parse: ok
+// sema: ok
 
 pragma IO_BIND[2:3]
 #pragma  __directive_info__ 0


### PR DESCRIPTION
Both "pragma" and "#pragma" are supported. But there was an error in checking the first character of "pragma".

Now pragmas are correct in the ASG