### PR TITLE
Remove all support for contextual keywords

### DIFF
--- a/crates/oq3_parser/src/parser.rs
+++ b/crates/oq3_parser/src/parser.rs
@@ -237,21 +237,6 @@ impl<'t> Parser<'t> {
     //     (ends_in_dot, marker)
     // }
 
-    // Unused. OQ3 has no contextual keywords.
-    // /// Advances the parser by one token, remapping its kind.
-    // /// This is useful to create contextual keywords from
-    // /// identifiers. For example, the lexer creates a `union`
-    // /// *identifier* token, but the parser remaps it to the
-    // /// `union` keyword, and keyword is what ends up in the
-    // /// final tree.
-    // pub(crate) fn _bump_remap(&mut self, kind: SyntaxKind) {
-    //     if self.current() == EOF {
-    //         // FIXME: panic!?
-    //         return;
-    //     }
-    //     self.do_bump(kind, 1);
-    // }
-
     /// Emit error with the `message`.
     /// FIXME (not GJL): this should be much more fancy and support
     /// structured errors with spans and notes, like rustc

--- a/crates/oq3_parser/src/shortcuts.rs
+++ b/crates/oq3_parser/src/shortcuts.rs
@@ -38,22 +38,18 @@ impl LexedStr<'_> {
                 // whitespace or comment
                 was_joint = false
             } else {
-                if kind == SyntaxKind::IDENT {
-                    let contextual_kw = SyntaxKind::IDENT;
-                    res.push_ident(contextual_kw);
-                } else {
-                    if was_joint {
-                        res.was_joint();
-                    }
-                    res.push(kind);
-                    // Tag the token as joint if it is float with a fractional part.
-                    // We use this jointness to inform the parser about what token split
-                    // event to emit when we encounter a float literal in a field access
-                    if kind == SyntaxKind::FLOAT_NUMBER && !self.text(i).ends_with('.') {
-                        res.was_joint();
-                    }
+                if was_joint {
+                    res.was_joint();
                 }
-
+                res.push(kind);
+                // Tag the token as joint if it is float with a fractional part.
+                // We use this jointness to inform the parser about what token split
+                // event to emit when we encounter a float literal in a field access
+                // TODO: At d0146087 test suite passes with following conditional
+                // deleted. Is it only that we are not testing for it?
+                if kind == SyntaxKind::FLOAT_NUMBER && !self.text(i).ends_with('.') {
+                    res.was_joint();
+                }
                 was_joint = true;
             }
         }

--- a/crates/oq3_syntax/build.rs
+++ b/crates/oq3_syntax/build.rs
@@ -900,14 +900,7 @@ mod sourcegen {
         let full_keywords_values = grammar.keywords;
         let full_keywords = full_keywords_values.iter().map(upper_snake);
 
-        // let contextual_keywords_values = &grammar.contextual_keywords;
-        // let contextual_keywords = contextual_keywords_values.iter().map(upper_snake);
-
         let all_keywords_values = grammar.keywords.to_vec();
-        // .iter()
-        // //        .chain(grammar.contextual_keywords.iter())
-        // .copied()
-        // .collect::<Vec<_>>();
         let all_keywords_idents = all_keywords_values.iter().map(|kw| format_ident!("{}", kw));
         let all_keywords = all_keywords_values
             .iter()

--- a/crates/oq3_syntax/openqasm3.ungram
+++ b/crates/oq3_syntax/openqasm3.ungram
@@ -1,6 +1,6 @@
 // This grammar specifies the structure of the OpenQASM 3 concrete syntax tree.
 // It does not specify parsing rules (ambiguities, precedence, etc are out of scope).
-// Tokens are processed -- contextual keywords are recognised, compound operators glued.
+// Tokens are processed -- compound operators glued.
 //
 // Legend:
 //


### PR DESCRIPTION
r-a needs to support contextual keywords. OQ3 does not. So we remove support.
Removing support reduces complexity and some storage and CPU cycles.

This means that if you are experimenting with extensions or changes to OpenQASM3 you won't be able to use contextual keywords. But it's fairly easy to add re-implement support for contextual keywords.